### PR TITLE
Move Anoma.Node to Anoma.Node.Executor

### DIFF
--- a/lib/anoma/node/executor.ex
+++ b/lib/anoma/node/executor.ex
@@ -1,6 +1,6 @@
-defmodule Anoma.Node do
+defmodule Anoma.Node.Executor do
   @moduledoc """
-  I am an Anoma node.
+  I am an incomplete Anoma Executor node.
   """
 
   use Supervisor
@@ -11,8 +11,8 @@ defmodule Anoma.Node do
 
   def init(name) do
     children = [
-      {Anoma.Node.Communicator, init: [], name: name},
-      {Anoma.Node.Primary, init: [], name: name}
+      {Anoma.Node.Executor.Communicator, init: [], name: name},
+      {Anoma.Node.Executor.Primary, init: [], name: name}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/anoma/node/executor/communicator.ex
+++ b/lib/anoma/node/executor/communicator.ex
@@ -1,4 +1,4 @@
-defmodule Anoma.Node.Communicator do
+defmodule Anoma.Node.Executor.Communicator do
   @moduledoc """
   I Manage the Pub Sub behavior
 

--- a/lib/anoma/node/executor/primary.ex
+++ b/lib/anoma/node/executor/primary.ex
@@ -1,6 +1,6 @@
-defmodule Anoma.Node.Primary do
+defmodule Anoma.Node.Executor.Primary do
   @moduledoc """
-  I represent the main logic checking functonality of an `Anoma.Node`.
+  I represent the main logic checking functonality of an `Anoma.Node.Executor`.
 
   I can be communicated by, by my public API, often this is done by my
   `Anoma.Node.Communicator`, however everything can communicate with

--- a/test/communicator_test.exs
+++ b/test/communicator_test.exs
@@ -1,13 +1,13 @@
 defmodule AnomaTest.Communicator do
   use ExUnit.Case, async: true
 
-  import Anoma.Node.Communicator
+  import Anoma.Node.Executor.Communicator
 
-  alias Anoma.Node.Communicator
+  alias Anoma.Node.Executor.Communicator
 
   alias Anoma.Subscriber.Basic
 
-  doctest(Anoma.Node.Communicator)
+  doctest(Anoma.Node.Executor.Communicator)
 
   test "subscribers properly get intents messages" do
     {_, comms} = GenServer.start_link(Communicator, [])

--- a/test/node_test.exs
+++ b/test/node_test.exs
@@ -1,10 +1,10 @@
 defmodule AnomaTest.Node do
   use ExUnit.Case, async: true
 
-  alias Anoma.Node.{Communicator, Primary}
-  alias Anoma.Node
+  alias Anoma.Node.Executor.{Communicator, Primary}
+  alias Anoma.Node.Executor
 
-  doctest(Anoma.Node)
+  doctest(Anoma.Node.Executor)
 
   test "node works" do
     # Node.start_link(:anoma)


### PR DESCRIPTION
The layout of Anoma.Node is ambiguious, as what is a the Primary Node? We have specific kinds of nodes, like intent pool nodes, memory pool nodes, etc.

To make it explicit what kind of node it is, we've moved it to be an Executor node, which is the closest node it can be.

What is there is a stub and should change, as an Executor node does a lot more than what is there