### PR TITLE
Create A node utilities module with common functions 

### DIFF
--- a/lib/anoma/node/communicator.ex
+++ b/lib/anoma/node/communicator.ex
@@ -17,6 +17,7 @@ defmodule Anoma.Node.Communicator do
   use TypedStruct
   use GenServer
   alias Anoma.Intent
+  alias Anoma.Node.Utility
 
   typedstruct do
     field(:subscribers, list(pid()), default: [])
@@ -33,21 +34,8 @@ defmodule Anoma.Node.Communicator do
   end
 
   def start_link(arg) do
-    # hack do better
-    name = arg[:name]
-
-    options =
-      if name do
-        [name: com_name(name)]
-      else
-        []
-      end
-
-    GenServer.start_link(__MODULE__, arg, options)
+    GenServer.start_link(__MODULE__, arg, Utility.name(arg, &Utility.com_name/1))
   end
-
-  @spec com_name(atom()) :: atom()
-  def com_name(name), do: (Atom.to_string(name) <> "_com") |> String.to_atom()
 
   ############################################################
   #                      Public RPC API                      #
@@ -91,19 +79,9 @@ defmodule Anoma.Node.Communicator do
   ############################################################
 
   # make this more interesting later
-  @spec broadcast_intent(t(), Intent.t()) :: [any()]
+  @spec broadcast_intent(t(), Intent.t()) :: :ok
   defp broadcast_intent(agent, intent) do
     # safe even on a null primary thanks to GenServer
-    broadcast([agent.primary | agent.subscribers], intent)
-  end
-
-  # Dirty send, maybe consider what the structure of a subscriber is
-  # further determine if it should live here
-  @spec broadcast(list(), Intent.t()) :: [any()]
-  defp broadcast(sub_list, intent) do
-    sub_list
-    # this is bad we are assuming GenServer, lets make this generic by
-    # passing in a module to do a cast or call or something.
-    |> Enum.map(fn sub -> GenServer.cast(sub, {:new_intent, intent}) end)
+    Utility.broadcast([agent.primary | agent.subscribers], {:new_intent, intent})
   end
 end

--- a/lib/anoma/node/primary.ex
+++ b/lib/anoma/node/primary.ex
@@ -12,6 +12,7 @@ defmodule Anoma.Node.Primary do
   use GenServer
 
   alias Anoma.Intent
+  alias Anoma.Node.Utility
 
   typedstruct do
     field(:intents, list(Intent.t()), default: [])
@@ -22,17 +23,7 @@ defmodule Anoma.Node.Primary do
   end
 
   def start_link(arg) do
-    # please do this better, it's duplicated in communicator!!!
-    name = arg[:name]
-
-    options =
-      if name do
-        [name: name]
-      else
-        []
-      end
-
-    GenServer.start_link(__MODULE__, arg, options)
+    GenServer.start_link(__MODULE__, arg, Utility.name(arg))
   end
 
   ############################################################

--- a/lib/anoma/node/utility.ex
+++ b/lib/anoma/node/utility.ex
@@ -77,7 +77,6 @@ defmodule Anoma.Node.Utility do
   @spec com_name(atom()) :: atom()
   def com_name(name), do: (Atom.to_string(name) <> "_com") |> String.to_atom()
 
-
   @doc """
   I broadcast a given term to all subscribers
 
@@ -91,7 +90,7 @@ defmodule Anoma.Node.Utility do
     # passing in a module to do a cast or call or something.
     subs
     |> Enum.map(fn sub -> GenServer.cast(sub, term) end)
+
     :ok
   end
-
 end


### PR DESCRIPTION
Here we serve to reduce repeat code by introducing two kinds of
utilities:

1. Argument Builders
2. Communciator abstractions

We will be making a lot of communicator's which means that these
utilities now have a central place to exist