### PR TITLE
Add helpers for creating random resources

### DIFF
--- a/lib/anoma/partialtx.ex
+++ b/lib/anoma/partialtx.ex
@@ -57,6 +57,25 @@ defmodule Anoma.PartialTx do
 
   def empty(), do: %PartialTx{}
 
+  @doc """
+
+  I help create an "unique" partial transaction, by making a partial
+  transaction including an empty resource with the binary of the given term.
+
+  ### Parameters
+
+     - `term` - any term one wishes to put in the resource
+
+  ### Output
+
+    - the semi-unique term
+
+  """
+  def unique_empty(term) do
+    empty()
+    |> add_input(Resource.make_empty(term))
+  end
+
   ######################################################################
   # Helpers
   ######################################################################

--- a/lib/anoma/resource.ex
+++ b/lib/anoma/resource.ex
@@ -30,6 +30,28 @@ defmodule Anoma.Resource do
   def new(num) do
     %Resource{quantity: num}
   end
+
+  @doc """
+
+  I help create a completely empty resource, with a given term as the
+  suffix.
+
+  This is mainly helpful in testing, as we can create unique empty
+  resources.
+
+  ## Parameters
+
+    - `suffix` - any term that will be turned into a binary for testing
+
+  ## Output
+
+    - The empty resource
+
+  """
+  @spec make_empty(term()) :: t()
+  def make_empty(suffix) do
+    %Resource{quantity: 0, suffix: :erlang.term_to_binary(suffix)}
+  end
 end
 
 defimpl Anoma.Intent, for: Anoma.Resource do


### PR DESCRIPTION
Before one had to manually create a resource and add it to the partial transaction.

Now it is easier to create these, with the two new function:

- Anoma.PartialTx.unqiue_empty(term)
- Anoma.Resource.make_empty(term)