### PR TITLE
ci: have all checks run even if one fails

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -84,13 +84,13 @@ jobs:
       run: mix test
 
     - name: Run dialyzer
-      if: steps.try_merge.outcome != 'failure'
+      if: ${{ !cancelled() }} && steps.try_merge.outcome != 'failure'
       run: mix dialyzer --format github
 
     - name: Format check
-      if: steps.try_merge.outcome != 'failure'
+      if: ${{ !cancelled() }} && steps.try_merge.outcome != 'failure'
       run: mix format --check-formatted
 
     - name: All files whitespace error check
-      if: steps.try_merge.outcome != 'failure'
+      if: ${{ !cancelled() }} && steps.try_merge.outcome != 'failure'
       run: git diff-tree --check 4b825dc642cb6eb9a060e54bf8d69288fbee4904 HEAD


### PR DESCRIPTION
Assuming setup reached any of the actual checks, they should all run,
not just until one fails.

I did write a parallel multi-job version of this CI pipeline, but am
not using it because the tests run so quickly that this just runs
slower and spends more CI minutes. It may be revisited if the test
suite ever grows slow.
