### PR TITLE
Update gitignore for VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ anoma-*.tar
 # Emacs git ignore
 *.*~
 \#*\#
+
+# VSCode git ignore
+.vscode/


### PR DESCRIPTION
We simply ignore the .vscode/ folder that vscode creates