### PR TITLE
Accept improper lists

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,8 @@ defmodule Anoma.MixProject do
       deps: deps(),
       dialyzer: [
         plt_local_path: "plts/anoma.plt",
-        plt_core_path: "plts/core.plt"
+        plt_core_path: "plts/core.plt",
+        flags: ["-Wno_improper_lists"]
       ]
     ]
   end


### PR DESCRIPTION
By default Dialyzer does not accept improper lists to pass the dialyzer test. However we may want to use them for Nock code, so we shall disable them until further notice