### PR TITLE
mix: specify elixir 1.15.6

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Anoma.MixProject do
     [
       app: :anoma,
       version: "0.2.0",
-      elixir: "~> 1.14",
+      elixir: "~> 1.15.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: [


### PR DESCRIPTION
The fuzzy ~> specifier is fine, because we don't want to error on the user's minor elixir version differences.