### PR TITLE
Add depednencies for Observer

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,14 @@ defmodule Anoma.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger, :crypto, :mnesia]
+      extra_applications: [
+        :logger,
+        :crypto,
+        :mnesia,
+        :observer,
+        :wx,
+        :runtime_tools
+      ]
     ]
   end
 


### PR DESCRIPTION
Observires relies on the following extra_applications:
1. observer
2. wx
3. runtime_tools

Without these, one can not start observer