### PR TITLE
Extend Nock's type to contain binary

### DIFF
--- a/lib/noun.ex
+++ b/lib/noun.ex
@@ -9,7 +9,7 @@ defmodule Noun do
 
   require Integer
 
-  @type t() :: non_neg_integer() | nonempty_improper_list(t(), t())
+  @type t() :: non_neg_integer() | nonempty_improper_list(t(), t()) | binary()
 
   # erlang has something called 'atom' already, so we say is_noun_atom
   defguard is_noun_atom(term) when is_integer(term) and term >= 0


### PR DESCRIPTION
This is useful, as wish to have nock work over binary data in time, and currently we store an id as a binary term that we send into Nock, which works just fine. The typing is simply too tight without this change