### PR TITLE
Update block to be more generic of data and table

### DIFF
--- a/lib/anoma/block.ex
+++ b/lib/anoma/block.ex
@@ -88,11 +88,15 @@ defmodule Anoma.Block do
 
   @spec encode(t()) :: tuple()
   def encode(block) do
-    {__MODULE__, block.id, block.block, block.round, block.pub_key,
-     block.signature}
+    encode(block, __MODULE__)
   end
 
-  def decode({__MODULE__, id, block, round, pub_key, sig}) do
+  @spec encode(t(), atom()) :: tuple()
+  def encode(block, atom) do
+    {atom, block.id, block.block, block.round, block.pub_key, block.signature}
+  end
+
+  def decode({_, id, block, round, pub_key, sig}) do
     %Block{
       id: id,
       block: block,

--- a/lib/anoma/block/base.ex
+++ b/lib/anoma/block/base.ex
@@ -13,12 +13,17 @@ defmodule Anoma.Block.Base do
   alias Anoma.Block.Base
 
   typedstruct do
-    field(:transactions, list(Anoma.PartialTx.t()), default: [])
+    field(:transactions, list(any()), default: [])
   end
 
   @spec default() :: t()
   def default() do
     %Base{}
+  end
+
+  @spec new(any()) :: t()
+  def new(transactions) do
+    %Base{transactions: transactions}
   end
 
   @spec digest(t()) :: binary()


### PR DESCRIPTION
Previously the encode function assumed writing to the module name, but we've freed this restriction

Further we have lowered the type requirement on what a block holds, as the RM is not there to dictate what it should be