### PR TITLE
Remove various warnings found throughout the project

### DIFF
--- a/lib/anoma/partialtx.ex
+++ b/lib/anoma/partialtx.ex
@@ -95,20 +95,18 @@ defmodule Anoma.PartialTx do
   # Helpers
   ######################################################################
 
-  @doc """
-  I update the resource set with the new resource
+  # I update the resource set with the new resource
 
+  # ### Parameters
 
-  ### Parameters
+  # - resource_set (resource_set()) - the resource set we are updating
 
-  - resource_set (resource_set()) - the resource set we are updating
+  # - new_resource (Resource.t()) - the resource we are adding
 
-  - new_resource (Resource.t()) - the resource we are adding
+  # ### Returns
 
-  ### Returns
+  # the updated resource set
 
-  the updated resource set
-  """
   @spec update_resource_set(resources, Resource.t()) :: resources
   defp update_resource_set(resource_set, new_resource) do
     denom = Resource.denomination(new_resource)
@@ -120,14 +118,6 @@ defmodule Anoma.PartialTx do
   @spec add_quantities(list(Resource.t())) :: integer()
   defp add_quantities(resources) do
     Enum.reduce(resources, 0, fn x, acc -> x.quantity + acc end)
-  end
-
-  @spec sub_quantities(Resource.t(), Resource.t()) :: Resource.t()
-  defp sub_quantities(resource_1, resource_2) do
-    %Resource{
-      resource_1
-      | quantity: resource_1.quantity - resource_2.quantity
-    }
   end
 end
 

--- a/test/block_test.exs
+++ b/test/block_test.exs
@@ -18,7 +18,7 @@ defmodule AnomaTest.Block do
   end
 
   test "no signature on startup" do
-    {pub, priv} = :crypto.generate_key(:rsa, {1024, 65537})
+    {pub, _priv} = :crypto.generate_key(:rsa, {1024, 65537})
     block = Block.create(Base.default(), pub, 0)
     assert block.signature == nil
   end

--- a/test/communicator_test.exs
+++ b/test/communicator_test.exs
@@ -1,11 +1,7 @@
 defmodule AnomaTest.Communicator do
   use ExUnit.Case, async: true
 
-  import Anoma.Node.Executor.Communicator
-
   alias Anoma.Node.Executor.Communicator
-
-  alias Anoma.Subscriber.Basic
 
   alias Anoma.PartialTx
   alias Anoma.Node.Executor, as: Node

--- a/test/intent_test.exs
+++ b/test/intent_test.exs
@@ -2,7 +2,7 @@ defmodule AnomaTest.Intent do
   use ExUnit.Case, async: true
 
   alias Anoma.Node.Intent
-  alias Anoma.Node.Intent.{Communicator, Pool}
+  alias Anoma.Node.Intent.Communicator
   alias Anoma.Resource
 
   doctest(Anoma.Node.Intent)
@@ -15,7 +15,7 @@ defmodule AnomaTest.Intent do
 
     Communicator.new_intent(:intents_add_com, resource)
     Communicator.subscribe(:intents_add_com, self())
-    assert_receive {:"$gen_cast", {:intents, resource_set}}
+    assert_receive {:"$gen_cast", {:intents, ^resource_set}}
 
     Communicator.new_intent(:intents_add_com, resource)
 
@@ -45,8 +45,8 @@ defmodule AnomaTest.Intent do
     Communicator.new_intent(:intents_signal_com, resource_1)
     Communicator.new_intent(:intents_signal_com, resource_1)
 
-    assert_receive {:"$gen_cast", {:new_intent, resource_1}}
-    assert_receive {:"$gen_cast", {:new_intent, resource_1}}
+    assert_receive {:"$gen_cast", {:new_intent, ^resource_1}}
+    assert_receive {:"$gen_cast", {:new_intent, ^resource_1}}
 
     Intent.shutdown(supervisor)
   end

--- a/test/logic_test.exs
+++ b/test/logic_test.exs
@@ -3,7 +3,7 @@ defmodule AnomaTest.Logic do
 
   alias Anoma.Logic.{Lt, Branch, Mul, Add, Inc, Neg}
 
-  alias Anoma.{Eval, PartialTx}
+  alias Anoma.Eval
 
   doctest(Anoma.Logic)
 

--- a/test/nock_test.exs
+++ b/test/nock_test.exs
@@ -2,7 +2,6 @@ defmodule AnomaTest.Nock do
   use ExUnit.Case, async: true
 
   import Nock
-  import Noun
 
   doctest(Nock)
 

--- a/test/node_test.exs
+++ b/test/node_test.exs
@@ -1,9 +1,6 @@
 defmodule AnomaTest.Node do
   use ExUnit.Case, async: true
 
-  alias Anoma.Node.Executor.{Communicator, Primary}
-  alias Anoma.Node.Executor
-
   doctest(Anoma.Node.Executor)
 
   test "node works" do

--- a/test/noun_test.exs
+++ b/test/noun_test.exs
@@ -2,7 +2,6 @@ defmodule AnomaTest.Noun do
   use ExUnit.Case, async: true
 
   import Noun
-  alias Noun.Format
 
   doctest(Noun)
   doctest(Noun.Format)

--- a/test/partialtx_test.exs
+++ b/test/partialtx_test.exs
@@ -1,10 +1,6 @@
 defmodule AnomaTest.PartialTx do
   use ExUnit.Case, async: true
 
-  alias Anoma.Node.Communicator
-
-  alias Anoma.Subscriber.Basic
-
   alias Anoma.PartialTx
 
   doctest(Anoma.PartialTx)


### PR DESCRIPTION
We remove all known warnings, this makes it nice as `mix test` and other commands will not spit any wanrings anymore