### PR TITLE
ci: correct skip conditions on main checks

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -84,13 +84,13 @@ jobs:
       run: mix test
 
     - name: Run dialyzer
-      if: ${{ !cancelled() }} && steps.try_merge.outcome != 'failure'
+      if: ${{ !cancelled() && steps.try_merge.outcome != 'failure' }}
       run: mix dialyzer --format github
 
     - name: Format check
-      if: ${{ !cancelled() }} && steps.try_merge.outcome != 'failure'
+      if: ${{ !cancelled() && steps.try_merge.outcome != 'failure' }}
       run: mix format --check-formatted
 
     - name: All files whitespace error check
-      if: ${{ !cancelled() }} && steps.try_merge.outcome != 'failure'
+      if: ${{ !cancelled() && steps.try_merge.outcome != 'failure' }}
       run: git diff-tree --check 4b825dc642cb6eb9a060e54bf8d69288fbee4904 HEAD


### PR DESCRIPTION
Attempting to && another condition outside the ${{}} braces, if such
braces are present, is not effective (the condition is ignored
silently). Move the try_merge conditional skip inside the braces on the
main test checks, so they are correctly skipped on next if the
attempted merge failed.
