### PR TITLE
Add script to run the nockma evaluator standalone

### DIFF
--- a/lib/nock/cli.ex
+++ b/lib/nock/cli.ex
@@ -1,0 +1,47 @@
+defmodule Nock.Cli do
+  import Nock
+  require Noun.Format
+
+  @spec argument_parser() :: Optimus.t()
+  def argument_parser() do
+    Optimus.new!(
+      name: "nockma",
+      description: """
+      Run the nockma evaluator on a file. \
+      The file should contain a single nockma cell: [subject formula]
+      """,
+      allow_unknown_args: false,
+      parse_double_dash: true,
+      args: [
+        infile: [
+          value_name: "INPUT_FILE",
+          help: "Nockma source file",
+          required: true,
+          parser: :string
+        ]
+      ],
+      options: [
+        outfile: [
+          value_name: "OUTPUT_FILE",
+          short: "-o",
+          long: "--output",
+          help: "A file to write the evaluation result",
+          parser: :string,
+          required: false,
+          default: nil
+        ]
+      ]
+    )
+  end
+
+  @spec main([binary()]) :: :ok
+  def main(argv) do
+    args = Optimus.parse!(argument_parser(), argv)
+    %{args: %{infile: infile}, options: %{outfile: outfile}} = args
+    outfile = outfile || infile <> ".result"
+    {:ok, contents} = File.read(infile)
+    {:ok, [subject | formula]} = Noun.Format.parse(contents)
+    {:ok, res} = nock(subject, formula)
+    :ok = File.write!(outfile, Noun.Format.print(res))
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,13 @@ defmodule Anoma.MixProject do
       ],
       # Docs
       name: "Anoma",
-      docs: docs()
+      docs: docs(),
+      # Nockma eval
+      escript: [
+        main_module: Nock.Cli,
+        name: "nockma",
+        app: nil
+      ]
     ]
   end
 
@@ -45,7 +51,8 @@ defmodule Anoma.MixProject do
       {:rexbug, ">= 2.0.0-rc1"},
       {:kino, "~> 0.12.2"},
       {:ex_doc, "~> 0.31", only: [:dev], runtime: false},
-      {:dialyxir, "~> 1.3", only: [:dev], runtime: false}
+      {:dialyxir, "~> 1.3", only: [:dev], runtime: false},
+      {:optimus, "~> 0.2"}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -11,6 +11,7 @@
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.3", "d684f4bac8690e70b06eb52dad65d26de2eefa44cd19d64a8095e1417df7c8fd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "b78dc853d2e670ff6390b605d807263bf606da3c82be37f9d7f68635bd886fc9"},
   "mnesia_rocksdb": {:git, "https://github.com/mariari/mnesia_rocksdb", "b07f7438af140947efed633c0391f0db839d95fb", []},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
+  "optimus": {:hex, :optimus, "0.5.0", "7050c0ea7fc448605d77c30bcf34c582919ae2ac1a92116d6c2d404bec822931", [:mix], [], "hexpm", "acfc75b341952d5d1dde8e0550425ecd3b656dfefa1bb4f14aea10005936378a"},
   "recon": {:hex, :recon, "2.5.4", "05dd52a119ee4059fa9daa1ab7ce81bc7a8161a2f12e9d42e9d551ffd2ba901c", [:mix, :rebar3], [], "hexpm", "e9ab01ac7fc8572e41eb59385efeb3fb0ff5bf02103816535bacaedf327d0263"},
   "recon_ex": {:hex, :recon_ex, "0.9.1", "51558b6eb347753dcf9c884ba68d49dbbec607fc4296815b72a0c8995d5d3203", [:mix], [{:recon, "~> 2.3.1", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm", "ca124759162c082adbb29078eadb9ab102425493c94387221d1e11acd0e050f7"},
   "redbug": {:hex, :redbug, "2.0.9", "47a0802ea5ca5f2c54bd9b0be429ff3ac839e85a277e97105d7e6107174b25f3", [:rebar3], [], "hexpm", "048cecdd53183a57e0f8a3f81bed2ea4c3ad424d319eabd5ef158b9fc3ea2c69"},


### PR DESCRIPTION
This commit adds an escript `nockma` which provides a CLI to the nockma evaluator. Running `nockma` does not start the anoma application.

> ./nockma --help
Run the nockma evaluator on a file. The file should contain a single nockma cell: [subject
  formula]

USAGE:
    nockma [--output OUTPUT_FILE] INPUT_FILE
    nockma --version
    nockma --help

ARGS:

    INPUT_FILE        Nockma source file

OPTIONS:

    -o, --output        A file to write the evaluation result