### PR TITLE
Change test_helper/nock.ex to be mounted from hoon directly

### DIFF
--- a/hoon/tests.hoon
+++ b/hoon/tests.hoon
@@ -1,10 +1,12 @@
-:: Load anoma.hoon into your environemnt as anoma
-:: then write .*  name  [0 2] to get the arm
-=use-dec =>  anoma
+/+  resource-machine
+!.
+=>  resource-machine
+|%
+++  use-dec
 |=  a=@ud
 (dec a)
 
-=fib =>  anoma
+++  fib
 |=  n=@ud
 =+  [b=1 a=0]
 |-
@@ -14,3 +16,4 @@
   b  (add a b)
   n  (dec n)
 ==
+--

--- a/lib/test_helper/nock.ex
+++ b/lib/test_helper/nock.ex
@@ -8,9 +8,9 @@ defmodule TestHelper.Nock do
 
   @spec using_dec_core() :: Noun.t()
   def using_dec_core() do
-    arm = Noun.Format.parse_always("[8 [9 342 0 63] 9 2 10 [6 0 14] 0 2]")
+    arm = Noun.Format.parse_always("[8 [9 342 0 255] 9 2 10 [6 0 14] 0 2]")
     sample = 999
-    [arm, sample | stdlib_core()]
+    [arm, sample | logics_core()]
   end
 
   @spec factorial() :: Noun.t()
@@ -26,9 +26,9 @@ defmodule TestHelper.Nock do
         9
         2
         10
-        [30 8 [9 342 0 255] 9 2 10 [6 0 62] 0 2]
+        [30 8 [9 342 0 1.023] 9 2 10 [6 0 62] 0 2]
         10
-        [6 [8 [9 20 0 255] 9 2 10 [6 [0 29] 0 28] 0 2] 0 12]
+        [6 [8 [9 20 0 1.023] 9 2 10 [6 [0 29] 0 28] 0 2] 0 12]
         0
         1
       ]
@@ -38,7 +38,7 @@ defmodule TestHelper.Nock do
       1
     ]")
     sample = 1
-    [arm, sample | stdlib_core()]
+    [arm, sample | logics_core()]
   end
 
   # TODO :: Add hoon code for this
@@ -46,13 +46,13 @@ defmodule TestHelper.Nock do
   def increment_counter_val(val) do
     arm = [[1 | val], 4, 12, [1 | 0], [0 | 6], 1, val | 0]
     sample = 0
-    [arm, sample | stdlib_core()]
+    [arm, sample | logics_core()]
   end
 
   # [%ctr 0]
   def zero_counter(val) do
     arm = [1, val | 0]
     sample = 0
-    [arm, sample | stdlib_core()]
+    [arm, sample | logics_core()]
   end
 end


### PR DESCRIPTION
Previously the file hoon/tests.hoon gave instructions on how to load it. It assumed inputting it into the dojo directly. Instead we decide to make it properly loadable like all other files in the Hoon directly.

A guide on a seperate branch shows how to do this, so it makes onboarding this easily.

Further since I made it rely on `resource-machine` rather than `anoma`, we have changed the `stdlib_core()` into `logics_core()` and have updated the references to be inline with the new changes.