### PR TITLE
Create an index for ExDoc generation

### DIFF
--- a/documentation/CONTRIBUTING.livemd
+++ b/documentation/CONTRIBUTING.livemd
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [Index](./index.livemd)
+* [Index](./index_docs.livemd)
   * [Contributing](./CONTRIBUTING.livemd)
     1. [IEx](./contributing/iex.livemd)
     2. [Observer](./contributing/observer.livemd)

--- a/documentation/contributing/git.livemd
+++ b/documentation/contributing/git.livemd
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [Index](../index.livemd)
+* [Index](../index_docs.livemd)
   * [Contributing](../CONTRIBUTING.livemd)
     * [Git](./git.livemd)
 

--- a/documentation/contributing/iex.livemd
+++ b/documentation/contributing/iex.livemd
@@ -2,7 +2,7 @@
 
 ## Index
 
-* [Index](../index.livemd)
+* [Index](../index_docs.livemd)
   * [Contributing](../CONTRIBUTING.livemd)
     * [IEx](./iex.livemd)
 

--- a/documentation/contributing/observer.livemd
+++ b/documentation/contributing/observer.livemd
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [Index](../index.livemd)
+* [Index](../index_docs.livemd)
   * [Contributing](../CONTRIBUTING.livemd)
     * [Observer](./observer.livemd)
 

--- a/documentation/contributing/testing.livemd
+++ b/documentation/contributing/testing.livemd
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [Index](../index.livemd)
+* [Index](../index_docs.livemd)
   * [Contributing](../CONTRIBUTING.livemd)
     * [Testing](./testing.livemd)
 

--- a/documentation/contributing/understanding.livemd
+++ b/documentation/contributing/understanding.livemd
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [Index](../index.livemd)
+* [Index](../index_docs.livemd)
   * [Contributing](../CONTRIBUTING.livemd)
     * [Understanding any module](./understanding.livemd)
 

--- a/documentation/index_docs.livemd
+++ b/documentation/index_docs.livemd
@@ -1,0 +1,1 @@
+index.livemd

--- a/documentation/visualization.livemd
+++ b/documentation/visualization.livemd
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [Index](./index.livemd)
+* [Index](./index_docs.livemd)
   * [Visualizing Anoma](./visualization.livemd)
     1. [Actors](./visualization/actors.livemd)
 

--- a/documentation/visualization/actors.livemd
+++ b/documentation/visualization/actors.livemd
@@ -4,7 +4,7 @@
 
 ## Index
 
-* [Index](../index.livemd)
+* [Index](../index_docs.livemd)
   * [Visualizing Anoma](../visualization.livemd)
     * [Actors](./actors.livemd)
 

--- a/mix.exs
+++ b/mix.exs
@@ -82,6 +82,7 @@ defmodule Anoma.MixProject do
 
   def group_for_extras() do
     [
+      "Guide Index": "documentation/index_docs.livemd",
       "Contributors Guide": ~r/documentation\/contributing\/.?/,
       "Contributors Guide": "documentation/CONTRIBUTING.livemd",
       "Visualizing Anoma": ~r/documentation\/visualization\/.?/,
@@ -93,6 +94,7 @@ defmodule Anoma.MixProject do
     [
       "README.md",
       "documentation/index.livemd",
+      "documentation/index_docs.livemd",
       "documentation/CONTRIBUTING.livemd",
       "documentation/contributing/iex.livemd",
       "documentation/contributing/observer.livemd",


### PR DESCRIPTION
We are able to do this by abusing symlinks. Sadly this means for Windows the generation may not be optimal, we should do this in an OS agnostic way.

Further we update every index link to go back to the index_docs.

We should maybe consider removing `index.livebook` entirely, however I'm unsure if we should go against convention here