### PR TITLE
Fix the typing issues of exeuction expecting a Noun.t()

### DIFF
--- a/lib/anoma/node/executor/communicator.ex
+++ b/lib/anoma/node/executor/communicator.ex
@@ -23,6 +23,7 @@ defmodule Anoma.Node.Executor.Communicator do
   - `state/1`
   - `subscribe/2`
   """
+  alias Anoma.Transaction
   alias __MODULE__
   use TypedStruct
   use Anoma.Communicator, sub_field: :subscribers
@@ -104,7 +105,11 @@ defmodule Anoma.Node.Executor.Communicator do
   The user gets back a process so it may keep track of sending
   messages to this task or terminating the task
   """
-  @spec fire_new_transaction(GenServer.server(), Noun.t(), Noun.t()) :: pid()
+  @spec fire_new_transaction(
+          GenServer.server(),
+          Noun.t(),
+          Transaction.execution()
+        ) :: pid()
   def fire_new_transaction(communicator, order, gate) do
     GenServer.call(communicator, {:transaction, order, gate})
   end

--- a/lib/anoma/node/mempool/communicator.ex
+++ b/lib/anoma/node/mempool/communicator.ex
@@ -5,6 +5,7 @@ defmodule Anoma.Node.Mempool.Communicator do
   alias Anoma.Communicator, as: ACom
 
   use TypedStruct
+  alias Anoma.Transaction
   alias Anoma.Node.Mempool.Primary
   alias Anoma.Node.Utility
 
@@ -33,7 +34,8 @@ defmodule Anoma.Node.Mempool.Communicator do
   @spec execute(GenServer.server()) :: non_neg_integer()
   @spec soft_reset(GenServer.server()) :: :ok
   @spec hard_reset(GenServer.server()) :: :ok
-  @spec tx(GenServer.server(), Noun.t()) :: Anoma.Transaction.t()
+  @spec tx(GenServer.server(), Transaction.execution()) ::
+          Anoma.Transaction.t()
   @spec pending_txs(GenServer.server()) :: list(Anoma.Transaction.t())
 
   defdelegate state(server), to: Primary

--- a/lib/anoma/node/mempool/primary.ex
+++ b/lib/anoma/node/mempool/primary.ex
@@ -46,7 +46,7 @@ defmodule Anoma.Node.Mempool.Primary do
     GenServer.call(server, :execute)
   end
 
-  @spec tx(GenServer.server(), Noun.t()) :: Transaction.t()
+  @spec tx(GenServer.server(), Transaction.execution()) :: Transaction.t()
   def tx(server, tx_code) do
     GenServer.call(server, {:tx, tx_code})
   end
@@ -111,7 +111,7 @@ defmodule Anoma.Node.Mempool.Primary do
   #                  Genserver Implementation                #
   ############################################################
 
-  @spec handle_tx(Noun.t(), t()) :: Transaction.t()
+  @spec handle_tx(Transaction.execution(), t()) :: Transaction.t()
   def handle_tx(tx_code, state) do
     random_tx_id = random_id()
     pid = Ecom.fire_new_transaction(state.executor, random_tx_id, tx_code)
@@ -208,7 +208,8 @@ defmodule Anoma.Node.Mempool.Primary do
     %Primary{state | transactions: [], round: 0}
   end
 
-  @spec persistent_transaction(Transaction.t()) :: {Noun.t(), Noun.t()}
+  @spec persistent_transaction(Transaction.t()) ::
+          {Noun.t(), Transaction.execution()}
   def persistent_transaction(trans) do
     {Transaction.id(trans), Transaction.transaction(trans)}
   end

--- a/lib/anoma/transaction.ex
+++ b/lib/anoma/transaction.ex
@@ -9,13 +9,15 @@ defmodule Anoma.Transaction do
   alias __MODULE__
   use TypedStruct
 
+  @type execution() :: {:kv | :rm, Noun.t()}
+
   typedstruct enforce: true do
     field(:id, Noun.t())
     field(:pid, pid())
-    field(:transaction, Noun.t())
+    field(:transaction, execution())
   end
 
-  @spec new(Noun.t(), pid(), Noun.t()) :: t()
+  @spec new(Noun.t(), pid(), execution()) :: t()
   def new(id, pid, transaction) do
     %Transaction{id: id, pid: pid, transaction: transaction}
   end
@@ -26,6 +28,6 @@ defmodule Anoma.Transaction do
   @spec id(t()) :: Noun.t()
   def id(t), do: t.id
 
-  @spec transaction(t()) :: Noun.t()
+  @spec transaction(t()) :: execution()
   def transaction(t), do: t.transaction
 end


### PR DESCRIPTION
This was changed with the new :rm backend, however the types were not properly updated, and thus what the tests really did in reality was send in a {:rm, Noun.t()} | {:kv, Noun.t()}. and thus we update the code to properly respect that