### PR TITLE
Replace all require: true from typedstruct with enforce: true

### DIFF
--- a/lib/anoma/block.ex
+++ b/lib/anoma/block.ex
@@ -26,10 +26,10 @@ defmodule Anoma.Block do
   @type public_key() :: [:crypto.key_id()]
 
   typedstruct do
-    field(:id, binary(), require: true)
-    field(:block, Base.t(), require: true)
+    field(:id, binary(), enforce: true)
+    field(:block, Base.t(), enforce: true)
     field(:round, non_neg_integer(), default: 0)
-    field(:pub_key, Serializer.public_key(), require: true)
+    field(:pub_key, Serializer.public_key(), enforce: true)
     field(:signature, binary())
   end
 

--- a/lib/anoma/node.ex
+++ b/lib/anoma/node.ex
@@ -35,7 +35,7 @@ defmodule Anoma.Node do
   alias Anoma.Node.Utility
   alias __MODULE__
 
-  typedstruct require: true do
+  typedstruct enforce: true do
     field(:mempool, GenServer.server())
     field(:ordering, GenServer.server())
     field(:executor, GenServer.server())

--- a/lib/anoma/node/intent/communicator.ex
+++ b/lib/anoma/node/intent/communicator.ex
@@ -14,7 +14,7 @@ defmodule Anoma.Node.Intent.Communicator do
 
   typedstruct do
     field(:subscribers, ACom.t(), default: ACom.new())
-    field(:pool, atom(), require: true)
+    field(:pool, atom(), enforce: true)
   end
 
   def init(name: name, init: subscribers) do

--- a/lib/anoma/node/mempool/communicator.ex
+++ b/lib/anoma/node/mempool/communicator.ex
@@ -9,7 +9,7 @@ defmodule Anoma.Node.Mempool.Communicator do
   alias Anoma.Node.Utility
 
   typedstruct do
-    field(:primary, GenServer.server(), require: true)
+    field(:primary, GenServer.server(), enforce: true)
     field(:subscribers, ACom.t(), default: ACom.new())
   end
 

--- a/lib/anoma/node/mempool/primary.ex
+++ b/lib/anoma/node/mempool/primary.ex
@@ -12,8 +12,8 @@ defmodule Anoma.Node.Mempool.Primary do
 
   @type transactions :: list(Transaction.t())
   typedstruct do
-    field(:ordering, GenServer.server(), require: true)
-    field(:executor, GenServer.server(), require: true)
+    field(:ordering, GenServer.server())
+    field(:executor, GenServer.server())
     field(:block_storage, atom(), default: Anoma.Block)
     field(:transactions, transactions, default: [])
     field(:round, non_neg_integer(), default: 0)

--- a/lib/anoma/node/storage/communicator.ex
+++ b/lib/anoma/node/storage/communicator.ex
@@ -16,7 +16,7 @@ defmodule Anoma.Node.Storage.Communicator do
   alias Anoma.Storage
 
   typedstruct do
-    field(:primary, atom(), require: true)
+    field(:primary, atom(), enforce: true)
     field(:subscribers, ACom.t(), default: ACom.new())
   end
 

--- a/lib/anoma/order.ex
+++ b/lib/anoma/order.ex
@@ -17,7 +17,7 @@ defmodule Anoma.Order do
     - `id` - the identification key path of the requested key
     - `pid` - the process identifier to message
   """
-  typedstruct require: true do
+  typedstruct enforce: true do
     field(:index, non_neg_integer())
     field(:id, any())
     field(:pid, pid())


### PR DESCRIPTION
It seems that typedstruct and field from Typedstruct does not error upon getting keys which it does not know about. This has left our code to have some errors hidden inside of it.

This topic replaces all those wiht the proper enforce.

Further we fixup new compiler errors that stem from this issue as well.

Namely the mempool tries to make it's map by using an empty primary, so the enforced fields have to be removed