### PR TITLE
Move Anoma.Sign to Anoma.Crypto.Sign

### DIFF
--- a/lib/anoma/crypto/sign.ex
+++ b/lib/anoma/crypto/sign.ex
@@ -1,4 +1,4 @@
-defmodule Anoma.Sign do
+defmodule Anoma.Crypto.Sign do
   @moduledoc false
 
   @type ed25519_public() :: <<_::256>>

--- a/lib/anoma/resource.ex
+++ b/lib/anoma/resource.ex
@@ -11,7 +11,7 @@ defmodule Anoma.Resource do
   alias __MODULE__
   use TypedStruct
 
-  alias Anoma.Sign
+  alias Anoma.Crypto.Sign
 
   typedstruct enforce: true do
     # resource logic

--- a/test/node/executor/worker_test.exs
+++ b/test/node/executor/worker_test.exs
@@ -121,7 +121,7 @@ defmodule AnomaTest.Node.Executor.Worker do
     Storage.ensure_new(storage)
     Communicator.reset(env.ordering)
 
-    keypair = Anoma.Sign.new_keypair()
+    keypair = Anoma.Crypto.Sign.new_keypair()
 
     in_resource = %{
       new_with_npk(keypair.public)

--- a/test/resource_test.exs
+++ b/test/resource_test.exs
@@ -5,7 +5,7 @@ defmodule AnomaTest.Resource do
   import Anoma.Resource
   alias Anoma.Resource.ProofRecord
   alias Anoma.Resource.Transaction
-  alias Anoma.Sign
+  alias Anoma.Crypto.Sign
 
   test "commitments and nullifiers" do
     keypair_a = Sign.new_keypair()


### PR DESCRIPTION
The rational for this move, is that I wish to expand the crypto folder with Symmetric, and other goodies.

Due to other topics using Anoma.Sign we may have to rebase other topics on this, or merge this in depending on the topic.