### PR TITLE
Remove all the moduledoc false

### DIFF
--- a/lib/anoma/crypto/encrypt.ex
+++ b/lib/anoma/crypto/encrypt.ex
@@ -1,6 +1,4 @@
 defmodule Anoma.Crypto.Encrypt do
-  @moduledoc false
-
   @type box_public() :: <<_::256>>
   @type box_secret() :: <<_::256>>
 

--- a/lib/anoma/crypto/sign.ex
+++ b/lib/anoma/crypto/sign.ex
@@ -1,6 +1,4 @@
 defmodule Anoma.Crypto.Sign do
-  @moduledoc false
-
   @type ed25519_public() :: <<_::256>>
   @type ed25519_secret() :: <<_::512>>
 

--- a/lib/anoma/resource/delta.ex
+++ b/lib/anoma/resource/delta.ex
@@ -1,6 +1,4 @@
 defmodule Anoma.Resource.Delta do
-  @moduledoc false
-
   # usually non_neg_integer, but not in execution
   @type t() :: %{binary() => integer()}
 

--- a/lib/anoma/resource/proof.ex
+++ b/lib/anoma/resource/proof.ex
@@ -1,6 +1,4 @@
 defmodule Anoma.Resource.Proof do
-  @moduledoc false
-
   use TypedStruct
 
   # a transparent resource logic proof is just the resource

--- a/lib/anoma/resource/proof_record.ex
+++ b/lib/anoma/resource/proof_record.ex
@@ -1,6 +1,4 @@
 defmodule Anoma.Resource.ProofRecord do
-  @moduledoc false
-
   alias __MODULE__
   use TypedStruct
 


### PR DESCRIPTION
These caused warnings all over the system when dumping docs see:

warning: documentation references type "Anoma.Resource.Delta.t()" but it is hidden or private
  lib/anoma/resource/transaction.ex:16: Anoma.Resource.Transaction (module)

This fixes it up for future documentation generation