### PR TITLE
Removes the lee-dohm generate elixir docs with just running the docs

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -155,7 +155,7 @@ jobs:
         run: /bin/false
 
       - name: Build docs
-        uses: lee-dohm/generate-elixir-docs@v1
+        run: mix docs
       - name: Publish to Pages
         uses: peaceiris/actions-gh-pages@v1.0.1
         env:


### PR DESCRIPTION
The dependency simply setup elixir for us to run mix docs, but that isn't needed as we do our setup already, so we can just `mix docs`