### PR TITLE
Use the standard rocksdb dependency

### DIFF
--- a/global_deps.exs
+++ b/global_deps.exs
@@ -9,7 +9,9 @@
   # until the next Kino release
   {:kino_kroki, "~> 0.1.0"},
   {:memoize, "~> 1.4.3"},
-  {:mnesia_rocksdb, git: "https://github.com/mariari/mnesia_rocksdb"},
+  {:mnesia_rocksdb,
+   git: "https://github.com/aeternity/mnesia_rocksdb",
+   ref: "ece9db2b0924f2d252cc761080bdc584de042d99"},
   {:msgpack, "~> 0.8.1"},
   {:murmur, "~> 2.0"},
   {:optimus, "~> 0.2"},


### PR DESCRIPTION
We fix the current spot in master which addresses the reason why we had this fork to begin with:

https://github.com/aeternity/mnesia_rocksdb/pull/51

Works on my machine at the very least