### PR TITLE
Ensure correct NPK encodings

### DIFF
--- a/lib/anoma/resource.ex
+++ b/lib/anoma/resource.ex
@@ -165,9 +165,9 @@ defmodule Anoma.Resource do
           0 -> true
           1 -> false
         end,
-      nonce: Noun.atom_integer_to_binary(nonce),
-      npk: Noun.atom_integer_to_binary(npk),
-      rseed: Noun.atom_integer_to_binary(rseed)
+      nonce: Noun.atom_integer_to_binary(nonce, 32),
+      npk: Noun.atom_integer_to_binary(npk, 32),
+      rseed: Noun.atom_integer_to_binary(rseed, 32)
     }
   end
 end

--- a/lib/noun.ex
+++ b/lib/noun.ex
@@ -146,6 +146,19 @@ defmodule Noun do
     [h | list_nock_to_erlang(t)]
   end
 
+  # Return binary if it's already long enough
+  @spec pad_trailing(binary(), non_neg_integer()) :: binary()
+  def pad_trailing(binary, len)
+      when is_binary(binary) and is_integer(len) and len >= 0 and
+             byte_size(binary) >= len do
+    binary
+  end
+
+  def pad_trailing(binary, len)
+      when is_binary(binary) and is_integer(len) and len >= 0 do
+    binary <> <<0::size((len - byte_size(binary)) * 8)>>
+  end
+
   @spec atom_integer_to_binary(0) :: <<>>
   # special case: zero is the empty binary
   def atom_integer_to_binary(0) do
@@ -162,6 +175,13 @@ defmodule Noun do
   @spec atom_integer_to_binary(binary()) :: binary()
   def atom_integer_to_binary(binary) when is_binary(binary) do
     binary
+  end
+
+  @spec atom_integer_to_binary(non_neg_integer(), non_neg_integer()) ::
+          binary()
+  def atom_integer_to_binary(integer, length)
+      when is_integer(integer) and integer >= 0 do
+    pad_trailing(:binary.encode_unsigned(integer, :little), length)
   end
 
   @spec atom_binary_to_integer(binary()) :: non_neg_integer()


### PR DESCRIPTION
Fixes issue #214 assuming that diagnosis https://github.com/anoma/anoma/issues/214#issuecomment-2009616817 is correct. More specifically, the following changes have been made:
* Added an arity 2 variant of `atom_integer_to_binary` allowing the size of the binary to be specified
* Modified `from_noun` to ensure that the nullifier public key outputed always has length 32

Note that the first two changes above are sufficient to make the reported `:enacl_nif.crypto_sign_open` argument error go away.