### PR TITLE
Change Pinger Start Functionality

### DIFF
--- a/lib/anoma/node.ex
+++ b/lib/anoma/node.ex
@@ -106,6 +106,8 @@ defmodule Anoma.Node do
         time: args[:ping_time]
       )
 
+    Anoma.Node.Pinger.start(pinger)
+
     {:ok,
      %Node{
        router: router,

--- a/lib/anoma/node/pinger.ex
+++ b/lib/anoma/node/pinger.ex
@@ -18,7 +18,6 @@ defmodule Anoma.Node.Pinger do
     time = args[:time]
     mempool = args[:mempool]
 
-    pinger(time)
     {:ok, %Pinger{mempool: mempool, time: time}}
   end
 
@@ -29,6 +28,16 @@ defmodule Anoma.Node.Pinger do
   """
   def set_timer(server, time) do
     Router.call(server, {:set, time})
+  end
+
+  def start(server) do
+    Router.call(server, :start)
+  end
+
+  def handle_call(:start, _from, state) do
+    pinger(state.time)
+
+    {:reply, "Pinger launched", state}
   end
 
   def handle_call({:set, time}, _from, state) do

--- a/test/node/pinger_test.exs
+++ b/test/node/pinger_test.exs
@@ -1,8 +1,9 @@
 defmodule AnomaTest.Node.Pinger do
   use ExUnit.Case, async: true
 
-  alias Anoma.Node.Mempool
-  alias Anoma.Node.Router
+  alias Anoma.Node.{Mempool, Router}
+  alias Anoma.Storage
+  alias Anoma.Node.Storage.Ordering
   import TestHelper.Nock
 
   setup_all do
@@ -19,7 +20,7 @@ defmodule AnomaTest.Node.Pinger do
         name: name,
         snapshot_path: snapshot_path,
         storage: storage,
-        block_storage: :mempool_blocks,
+        block_storage: :pinger_blocks,
         ping_time: 1
       )
 
@@ -30,17 +31,47 @@ defmodule AnomaTest.Node.Pinger do
 
   test "Execution is done automatically", %{node: node} do
     key = 555
+    storage = Ordering.get_storage(node.ordering)
+    increment = increment_counter_val(key)
     zero = zero_counter(key)
 
-    assert :ok =
-             Router.call(
-               node.router,
-               {:subscribe_topic, node.executor_topic.id, :local}
-             )
+    ex_id = node.executor_topic.id
+    mem_t = node.mempool_topic
+
+    :ok =
+      Router.call(
+        node.router,
+        {:subscribe_topic, ex_id, :local}
+      )
+
+    Mempool.hard_reset(node.mempool)
+
+    :ok = Router.call(node.router, {:subscribe_topic, mem_t, :local})
 
     pid_zero = Mempool.tx(node.mempool, {:kv, zero}).pid
 
+    assert_receive {:"$gen_cast", {_, {:submitted, _}}}
+
+    pid_one = Mempool.tx(node.mempool, {:kv, increment}).pid
+    pid_two = Mempool.tx(node.mempool, {:kv, increment}).pid
+
     assert_receive {:"$gen_cast", {_, {:process_done, ^pid_zero}}}
+    assert_receive {:"$gen_cast", {_, {:process_done, ^pid_one}}}
+    assert_receive {:"$gen_cast", {_, {:process_done, ^pid_two}}}
+
+    assert {:ok, 2} = Storage.get(storage, key)
+
+    :ok =
+      Router.call(
+        node.router,
+        {:unsubscribe_topic, ex_id, :local}
+      )
+
+    :ok =
+      Router.call(
+        node.router,
+        {:unsubscribe_topic, mem_t, :local}
+      )
 
     Anoma.Node.Pinger.set_timer(node.pinger, :no_timer)
   end


### PR DESCRIPTION
Removes pinger startup on init and instead moved it into a separate command. Launch pinger with said command during Node launch.