### PR TITLE
Delete Ordering Subscription

### DIFF
--- a/lib/anoma/node/storage/ordering.ex
+++ b/lib/anoma/node/storage/ordering.ex
@@ -39,7 +39,6 @@ defmodule Anoma.Node.Storage.Ordering do
 
     # idempotent
     Storage.setup(return.table)
-    :mnesia.subscribe({:table, return.table.qualified, :simple})
     {:ok, return}
   end
 


### PR DESCRIPTION
Deleters the Ordering subscription. This ought to stop the CI bugs when the Ordering received messages from the Logger on ordering storage writes.