### PR TITLE
[feat] Key removal from Storage

### DIFF
--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -28,6 +28,32 @@ defmodule AnomaTest.Storage do
       assert {:ok, 1} = Storage.get(storage, testing_atom)
     end
 
+    test "Deleting key works", %{storage: storage} do
+      testing_atom = :QWERTZ_delete
+      assert {:atomic, :ok} = Storage.put(storage, testing_atom, 1)
+      assert {:atomic, :ok} = Storage.put(storage, testing_atom, 2)
+      assert {:ok, 2} = Storage.get(storage, testing_atom)
+      assert {:atomic, :ok} = Storage.delete_key(storage, testing_atom)
+      assert {:ok, 1} = Storage.get(storage, testing_atom)
+    end
+
+    test "Deleting key works (last)", %{storage: storage} do
+      testing_atom = :QWERTZ_delete_last
+      assert {:atomic, :ok} = Storage.put(storage, testing_atom, 1)
+      assert {:ok, 1} = Storage.get(storage, testing_atom)
+      assert {:atomic, :ok} = Storage.delete_key(storage, testing_atom)
+      assert :absent = Storage.get(storage, testing_atom)
+    end
+
+    test "Deleting all by key works", %{storage: storage} do
+      testing_atom = :QWERTZ_delete_all
+      assert {:atomic, :ok} = Storage.put(storage, testing_atom, 1)
+      assert {:atomic, :ok} = Storage.put(storage, testing_atom, 2)
+      assert {:ok, 2} = Storage.get(storage, testing_atom)
+      assert {:atomic, :ok} = Storage.delete_key_all(storage, testing_atom)
+      assert :absent = Storage.get(storage, testing_atom)
+    end
+
     test "block_reads work", %{storage: storage} do
       testing_atom = :QWERTZ_blocking
       assert {:atomic, :ok} = Storage.put(storage, testing_atom, 1)


### PR DESCRIPTION
Implement key removal feature in Storage.
The following functions are introduced
- `delete_key` removes last key entry relative to the order
- `delete_key_all` removes all key entries

Based on `v0.10.0`

Closes #317 