### PR TITLE
Add Clean Dump

### DIFF
--- a/lib/anoma/mnesia.ex
+++ b/lib/anoma/mnesia.ex
@@ -59,4 +59,20 @@ defmodule Anoma.Mnesia do
     catch_all = [{:"$1", [], [:"$$"]}]
     :mnesia.dirty_select(table, catch_all)
   end
+
+  @doc """
+  I help dump all data in a given table in a non-dirty way.
+
+  See `dirty_dump/1`
+  """
+
+  def dump(table) do
+    catch_all = [{:"$1", [], [:"$$"]}]
+    select = fn -> :mnesia.select(table, catch_all) end
+
+    case :mnesia.transaction(select) do
+      {:atomic, res} -> {:ok, res}
+      _ -> :error
+    end
+  end
 end


### PR DESCRIPTION
Adds a `dump/1` function to Mnesia allowing for non-dirty dumping of tables.