### PR TITLE
Calculate the heading properly for TOC generation

### DIFF
--- a/lib/livebook.ex
+++ b/lib/livebook.ex
@@ -120,6 +120,7 @@ defmodule Livebook do
     # going to a sister after nesting
     |> Enum.reduce({[], 0, 0, []}, fn {file, depth_f},
                                       {list, depth_prev, last, stack} ->
+      up_n = depth_prev - depth_f
       # If the previous depth agrees, increment the numbers
       cond do
         # The previous filing was our sister
@@ -132,8 +133,8 @@ defmodule Livebook do
 
         # The previous file is a sister of one of our ancestors
         depth_f < depth_prev ->
-          {[{file, depth_f, hd(stack) + 1} | list], depth_f, hd(stack) + 1,
-           tl(stack)}
+          {[{file, depth_f, hd(stack) + 1} | list], depth_f,
+           Enum.at(stack, up_n - 1) + 1, Enum.drop(stack, up_n)}
       end
     end)
     |> elem(0)


### PR DESCRIPTION
Before I would only hop back 1, assuming that we'd only ever go back 1 slot in docs.

This code still has a bug where if we skip 2 levels, we will similarly cause bugs, but for now I don't care about that case