### PR TITLE
Associate each router with a namespace.

### DIFF
--- a/lib/anoma/identity/name.ex
+++ b/lib/anoma/identity/name.ex
@@ -7,16 +7,17 @@ defmodule Anoma.Identity.Name do
   typedstruct do
     field(:storage, Storage.t())
     field(:keyspace, atom())
+    field(:name, binary())
   end
 
-  @spec reserve_namespace(t(), binary(), Id.Extern.t(), binary()) ::
+  @spec reserve_namespace(t(), Id.Extern.t(), binary()) ::
           :already_there | :improper_data | :ok | :failed_placement
-  def reserve_namespace(namespace = %__MODULE__{}, name, pub, cdata)
-      when is_binary(name) do
-    with true <- Verification.verify_request(cdata, name, pub),
-         :absent <- Storage.get(namespace.storage, [name_space(), name]),
+  def reserve_namespace(namespace = %__MODULE__{}, pub, cdata) do
+    with true <- Verification.verify_request(cdata, namespace.name, pub),
+         :absent <-
+           Storage.get(namespace.storage, [name_space(), namespace.name]),
          {:atomic, :ok} <-
-           Storage.put(namespace.storage, [name_space(), name], pub) do
+           Storage.put(namespace.storage, [name_space(), namespace.name], pub) do
       :ok
     else
       {:ok, _} -> :already_there
@@ -31,12 +32,11 @@ defmodule Anoma.Identity.Name do
   """
   @spec add(t(), binary(), {list(binary()), binary()}) ::
           :ok | :no_namespace | :failed_placement | :improper_data
-  def add(namespace = %__MODULE__{}, sig, d = {name, new_key})
-      when is_list(name) do
+  def add(namespace = %__MODULE__{}, sig, d = {name, new_key}) do
     store = namespace.storage
-    storage_space = [name_space() | name]
+    storage_space = [name_space() | [namespace.name | name]]
 
-    with {:ok, pub} <- Storage.get(store, [name_space(), hd(name)]),
+    with {:ok, pub} <- Storage.get(store, [name_space(), namespace.name]),
          true <- Verification.verify_request(sig, d, pub),
          :absent <- Storage.get(namespace.storage, storage_space),
          {:atomic, :ok} <- Storage.put(store, storage_space, new_key) do
@@ -49,9 +49,65 @@ defmodule Anoma.Identity.Name do
     end
   end
 
-  @spec all_identities(t(), binary()) :: MapSet.t(Id.Extern.t())
-  def all_identities(namespace = %__MODULE__{}, name) when is_binary(name) do
-    Storage.get_keyspace(namespace.storage, [name_space(), name])
+  @doc """
+  Adds the given key to the given namespace. The signer who owns the
+  namespace must have signed.
+  """
+  @spec put(t(), binary(), {list(binary()), binary()}) ::
+          :ok | :no_namespace | :failed_placement | :improper_data
+  def put(namespace = %__MODULE__{}, sig, d = {name, new_key}) do
+    store = namespace.storage
+    storage_space = [name_space() | [namespace.name | name]]
+
+    with {:ok, pub} <- Storage.get(store, [name_space(), namespace.name]),
+         true <- Verification.verify_request(sig, d, pub),
+         {:atomic, :ok} <- Storage.put(store, storage_space, new_key) do
+      :ok
+    else
+      :absent -> :no_namespace
+      {:aborted, _} -> :failed_placement
+      false -> :improper_data
+    end
+  end
+
+  @doc """
+  Adds the given key to the given namespace. The signer who owns the
+  namespace must have signed.
+  """
+  @spec get(t(), list(binary())) ::
+          :ok | :no_namespace
+  def get(namespace = %__MODULE__{}, name) do
+    store = namespace.storage
+    storage_space = [name_space() | [namespace.name | name]]
+
+    with {:ok, _} <- Storage.get(store, [name_space(), namespace.name]) do
+      Storage.get(namespace.storage, storage_space)
+    else
+      :absent -> :no_namespace
+    end
+  end
+
+  @doc """
+  Adds the given key to the given namespace. The signer who owns the
+  namespace must have signed.
+  """
+  @spec get(t(), list(binary())) ::
+          :ok | :no_namespace
+  def get_keyspace(namespace = %__MODULE__{}, name)
+      when is_list(name) do
+    store = namespace.storage
+    storage_space = [name_space() | [namespace.name | name]]
+
+    with {:ok, _} <- Storage.get(store, [name_space(), namespace.name]) do
+      Storage.get_keyspace(namespace.storage, storage_space)
+    else
+      :absent -> :no_namespace
+    end
+  end
+
+  @spec all_identities(t()) :: MapSet.t(Id.Extern.t())
+  def all_identities(namespace = %__MODULE__{}) do
+    Storage.get_keyspace(namespace.storage, [name_space(), namespace.name])
     |> Stream.map(fn {_, id} -> id end)
     |> MapSet.new()
   end

--- a/lib/anoma/node/executor/communicator.ex
+++ b/lib/anoma/node/executor/communicator.ex
@@ -32,15 +32,21 @@ defmodule Anoma.Node.Executor do
   alias Anoma.Node.Logger
 
   typedstruct do
+    field(:router, Router.Addr.t(), enforce: true)
     field(:task_completion_topic, Router.Addr.t())
     field(:ambiant_env, Nock.t())
     field(:tasks, list(Task.t()), default: [])
     field(:logger, Router.Addr.t(), enforce: false)
   end
 
-  def init({env, topic, logger}) do
+  def init({env, topic, logger, router}) do
     {:ok,
-     %Executor{ambiant_env: env, task_completion_topic: topic, logger: logger}}
+     %Executor{
+       ambiant_env: env,
+       task_completion_topic: topic,
+       logger: logger,
+       router: router
+     }}
   end
 
   ############################################################
@@ -116,7 +122,7 @@ defmodule Anoma.Node.Executor do
     iex> alias Anoma.Node.{Executor, Router}
     iex> {:ok, router} = Router.start
     iex> snap = %{snapshot_path: [:a | 0], ordering: nil}
-    iex> args = {snap, Router.new_topic(router), nil}
+    iex> args = {snap, Router.new_topic(router), nil, router}
     iex> {:ok, addr} = Router.start_engine(router, Executor, args)
     iex> Executor.snapshot(addr)
     :a

--- a/lib/anoma/storage.ex
+++ b/lib/anoma/storage.ex
@@ -254,7 +254,6 @@ defmodule Anoma.Storage do
   def write_at_order(storage, key, value, order) do
     write_tx = fn ->
       :mnesia.write({storage.order, key, order})
-
       :mnesia.write({storage.qualified, [order, key | 0], value})
     end
 

--- a/lib/nock.ex
+++ b/lib/nock.ex
@@ -8,7 +8,6 @@ defmodule Nock do
 
   use TypedStruct
 
-  alias Anoma.Storage
   alias __MODULE__
   alias Anoma.Node.Storage.Ordering
   alias Anoma.Node.Router
@@ -28,6 +27,7 @@ defmodule Nock do
 
   """
   typedstruct do
+    field(:router, Router.Addr.t() | nil, default: nil)
     field(:jet, jettedness(), default: :jetted)
     field(:ordering, Router.Addr.t() | nil, default: nil)
     field(:snapshot_path, Noun.t() | nil, default: nil)
@@ -1247,7 +1247,8 @@ defmodule Nock do
            snap_id = [id | env.snapshot_path],
            {:ok, snap} <- Ordering.caller_blocking_read_id(ordering, snap_id),
            instrument({:snapshot, snap}),
-           {:ok, value} <- Storage.get_at_snapshot(snap, key) do
+           {:ok, value} <-
+             Router.call(env.router, {:storage_get_at_snapshot, snap, key}) do
         instrument({:got_value, value})
         {:ok, value}
       else

--- a/test/identity/name_test.exs
+++ b/test/identity/name_test.exs
@@ -26,7 +26,7 @@ defmodule AnomaTest.Identity.Name do
 
     Storage.ensure_new(storage)
 
-    namespace = %Name{storage: storage, keyspace: tab}
+    namespace = %Name{storage: storage, keyspace: tab, name: "Alice"}
 
     [ns: namespace, st: storage, mem: mem]
   end
@@ -36,7 +36,7 @@ defmodule AnomaTest.Identity.Name do
     {%{commitment: com}, pub} = Manager.generate(mem, :ed25519, :commit)
     {:ok, commited} = Commitment.commit(com, "Alice")
     name = [Name.name_space(), "Alice"]
-    assert Name.reserve_namespace(namespace, "Alice", pub, commited) == :ok
+    assert Name.reserve_namespace(namespace, pub, commited) == :ok
     assert Storage.get_keyspace(storage, name) == [{name, pub}]
   end
 
@@ -45,13 +45,10 @@ defmodule AnomaTest.Identity.Name do
     # First pass all good
     {%{commitment: com}, pub} = Manager.generate(mem, :ed25519, :commit)
     {:ok, commited} = Commitment.commit(com, "Alice")
-    assert Name.reserve_namespace(namespace, "Alice", pub, commited) == :ok
+    assert Name.reserve_namespace(namespace, pub, commited) == :ok
     # no longer good
-    assert Name.reserve_namespace(namespace, "Alice", pub, commited) ==
+    assert Name.reserve_namespace(namespace, pub, commited) ==
              :already_there
-
-    assert Name.reserve_namespace(namespace, "A", pub, commited) ==
-             :improper_data
   end
 
   test "Adding to a namespace", %{ns: namespace, mem: mem, st: storage} do
@@ -59,11 +56,11 @@ defmodule AnomaTest.Identity.Name do
     {%{commitment: com}, pub} = Manager.generate(mem, :ed25519, :commit)
     {:ok, commited} = Commitment.commit(com, "Alice")
 
-    assert Name.reserve_namespace(namespace, "Alice", pub, commited) == :ok
+    assert Name.reserve_namespace(namespace, pub, commited) == :ok
 
     {_, new_identity} = Manager.generate(mem, :ed25519, :commit)
 
-    keyspace = ["Alice", "Urbit"]
+    keyspace = ["Urbit"]
 
     {:ok, attestation} =
       Commitment.commit(com, {keyspace, new_identity})
@@ -76,10 +73,7 @@ defmodule AnomaTest.Identity.Name do
     assert Name.add(namespace, attestation, {keyspace, ["Alice", "Anoma"]}) ==
              :improper_data
 
-    assert Name.add(namespace, attestation, {["Londo", "Narn"], new_identity}) ==
-             :no_namespace
-
-    assert Name.all_identities(namespace, "Alice") ==
+    assert Name.all_identities(namespace) ==
              MapSet.new([new_identity, pub])
   end
 end

--- a/test/node/mempool_test.exs
+++ b/test/node/mempool_test.exs
@@ -32,7 +32,6 @@ defmodule AnomaTest.Node.Mempool do
 
   test "successful process", %{node: node} do
     key = 555
-    storage = Ordering.get_storage(node.ordering)
     increment = increment_counter_val(key)
     zero = zero_counter(key)
 
@@ -54,7 +53,7 @@ defmodule AnomaTest.Node.Mempool do
     assert_receive {:"$gen_cast", {_, {:process_done, ^pid_zero}}}
     assert_receive {:"$gen_cast", {_, {:process_done, ^pid_one}}}
     assert_receive {:"$gen_cast", {_, {:process_done, ^pid_two}}}
-    assert {:ok, 2} = Storage.get(storage, key)
+    assert {:ok, 2} = Router.call(node.router, {:storage_get, key})
 
     :ok =
       Router.call(


### PR DESCRIPTION
This PR addresses issue #261 . More specifically, the following changes have been made:
* A namespace with the Router's ID is now reserved every time a `Router` is initialized
* The namespace structure has been augmented to include the name of the namespace
* Most accesses and writes to storage are now done through the `Router` API for the following reasons:
  * The `Router` possesses the signing key necessary to write into a `Router`'s namespace
  * The `Router` possesses the namespace that must be prepended to any key being manipulated
* Modified the tests to ensure that `Router`s are now parameterized by a namespace