### PR TITLE
Add Block Round Writing

### DIFF
--- a/lib/anoma/block.ex
+++ b/lib/anoma/block.ex
@@ -59,7 +59,12 @@ defmodule Anoma.Block do
   end
 
   def create(block, pub, round) do
-    %Block{block: block, pub_key: pub, id: signable(block, pub, round)}
+    %Block{
+      block: block,
+      pub_key: pub,
+      id: signable(block, pub, round),
+      round: round
+    }
   end
 
   @doc """


### PR DESCRIPTION
Fixes bug #392 where all blocks produced have round 0. Now blocks created
actually write their fed-in round.