### PR TITLE
Fixing the rare race condition in the storage tests.

### DIFF
--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -93,7 +93,6 @@ defmodule AnomaTest.Storage do
       assert Process.alive?(pid) == true
       Storage.put(storage, testing_atom, 1)
       assert_receive {:read, 1}, 100
-      assert Process.alive?(pid) == false
     end
   end
 


### PR DESCRIPTION
An attempt to address issue #345 . This PR concerns `test "blocking_reads really do block"` of `test/storagee_test.exs`. The only change made is to remove the line, `assert Process.alive?(pid) == false`, which seems to be logically redundant.

Logically, if `assert_receive {:read, 1}, 100` passes, then it must be the case that `send(home, {:read, value})` executed in the spawned process, and since this was that process' last instruction, it must terminate afterwards in finite time. Hence there should be no need to `assert Process.alive?(pid) == false` at the end of the test.