### PR TITLE
Use Block-checking Upon Loading

### DIFF
--- a/lib/anoma/dump.ex
+++ b/lib/anoma/dump.ex
@@ -96,7 +96,7 @@ defmodule Anoma.Dump do
     node_settings = [
       new_storage: false,
       name: name,
-      settings: load,
+      settings: settings,
       use_rocks: load[:use_rocks]
     ]
 


### PR DESCRIPTION
On v0.13.0 compilation issued a warning that a variable `settings` was not used before. This was due to the fact that during conflict resolution with a branch integrating a rocksdb option based on a previous version of the loading, the branch's options were fully taken instead of using a block-sync parameter.

This is changed and now the settings fed into the node are the ones syncing the blocks.