### PR TITLE
Allow our jets to run on binary atom's

### DIFF
--- a/lib/nock/jets.ex
+++ b/lib/nock/jets.ex
@@ -16,99 +16,89 @@ defmodule Nock.Jets do
     :error
   end
 
+  defp an_integer(x), do: Noun.atom_binary_to_integer(x)
+
   def dec(core) do
-    maybe_sample = sample(core)
-
-    case maybe_sample do
-      {:ok, sample} when is_noun_atom(sample) and sample > 0 ->
-        {:ok, sample - 1}
-
-      _ ->
-        :error
+    with {:ok, noun} when is_noun_atom(noun) <- sample(core),
+         sample when sample > 0 <- an_integer(noun) do
+      {:ok, sample - 1}
+    else
+      _ -> :error
     end
   end
 
   def add(core) do
-    maybe_sample = sample(core)
-
-    case maybe_sample do
-      {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) ->
-        {:ok, a + b}
-
-      _ ->
-        :error
+    with {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) <-
+           sample(core) do
+      {:ok, an_integer(a) + an_integer(b)}
+    else
+      _ -> :error
     end
   end
 
   def sub(core) do
-    maybe_sample = sample(core)
-
-    case maybe_sample do
-      {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) and a >= b ->
-        {:ok, a - b}
-
-      _ ->
-        :error
+    with {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) <-
+           sample(core),
+         {c, d} when c >= d <- {an_integer(a), an_integer(b)} do
+      {:ok, c - d}
+    else
+      _ -> :error
     end
   end
 
   def lth(core) do
-    maybe_sample = sample(core)
-
-    case maybe_sample do
-      {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) and a < b ->
+    with {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) <-
+           sample(core),
+         {c, d} = {an_integer(a), an_integer(b)} do
+      if c < d do
         {:ok, 0}
-
-      {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) ->
+      else
         {:ok, 1}
-
-      _ ->
-        :error
+      end
+    else
+      _ -> :error
     end
   end
 
   def lte(core) do
-    maybe_sample = sample(core)
-
-    case maybe_sample do
-      {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) and a <= b ->
+    with {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) <-
+           sample(core),
+         {c, d} = {an_integer(a), an_integer(b)} do
+      if c <= d do
         {:ok, 0}
-
-      {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) ->
+      else
         {:ok, 1}
-
-      _ ->
-        :error
+      end
+    else
+      _ -> :error
     end
   end
 
   def gth(core) do
-    maybe_sample = sample(core)
-
-    case maybe_sample do
-      {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) and a > b ->
+    with {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) <-
+           sample(core),
+         {c, d} = {an_integer(a), an_integer(b)} do
+      if c > d do
         {:ok, 0}
-
-      {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) ->
+      else
         {:ok, 1}
-
-      _ ->
-        :error
+      end
+    else
+      _ -> :error
     end
   end
 
   def gte(core) do
-    maybe_sample = sample(core)
-
-    case maybe_sample do
-      {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) and a >= b ->
+    with {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) <-
+           sample(core),
+         {c, d} = {an_integer(a), an_integer(b)} do
+      if c >= d do
         {:ok, 0}
-
-      {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) ->
+      else
         {:ok, 1}
-
-      _ ->
-        :error
+      end
+    else
+      _ -> :error
     end
   end
 
@@ -117,7 +107,7 @@ defmodule Nock.Jets do
 
     case maybe_sample do
       {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) ->
-        {:ok, a * b}
+        {:ok, an_integer(a) * an_integer(b)}
 
       _ ->
         :error
@@ -125,26 +115,22 @@ defmodule Nock.Jets do
   end
 
   def div(core) do
-    maybe_sample = sample(core)
-
-    case maybe_sample do
-      {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) and b != 0 ->
-        {:ok, Kernel.div(a, b)}
-
-      _ ->
-        :error
+    with {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) <-
+           sample(core),
+         {c, d} when d != 0 <- {an_integer(a), an_integer(b)} do
+      {:ok, Kernel.div(c, d)}
+    else
+      _ -> :error
     end
   end
 
   def mod(core) do
-    maybe_sample = sample(core)
-
-    case maybe_sample do
-      {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) and b != 0 ->
-        {:ok, Kernel.rem(a, b)}
-
-      _ ->
-        :error
+    with {:ok, [a | b]} when is_noun_atom(a) and is_noun_atom(b) <-
+           sample(core),
+         {c, d} when d != 0 <- {an_integer(a), an_integer(b)} do
+      {:ok, Kernel.rem(c, d)}
+    else
+      _ -> :error
     end
   end
 end

--- a/test/nock_test.exs
+++ b/test/nock_test.exs
@@ -41,6 +41,11 @@ defmodule AnomaTest.Nock do
     test "call with changing arguments" do
       assert nock(using_dec_core(), [9, 2, 10, [6, 1 | 5], 0 | 1]) == {:ok, 4}
     end
+
+    test "dec works on binaries" do
+      assert nock(using_dec_core(), [9, 2, 10, [6, 1 | <<22>>], 0 | 1]) ==
+               {:ok, 21}
+    end
   end
 
   describe "Standard Library" do


### PR DESCRIPTION
Binaries are atoms, so we should convert out of the binary form when running the atoms.

```elixir
iex(mariari@Gensokyo)43> nock(using_dec_core(), [9, 2, 10, [6, 1 | <<22>>], 0 | 1]) ** (ArithmeticError) bad argument in arithmetic expression: <<22>> - 1
    :erlang.-(<<22>>, 1)
    (anoma 0.13.0) lib/nock/jets.ex:169: Nock.Jets.dec/1
    (anoma 0.13.0) lib/nock.ex:151: Nock.nock/3
    (anoma 0.13.0) lib/nock.ex:336: Nock.naive_nock/3
    (anoma 0.13.0) lib/nock.ex:269: Nock.naive_nock/3
    iex:43: (file)
iex(mariari@Gensokyo)43> recompile
:ok
iex(mariari@Gensokyo)44> nock(using_dec_core(), [9, 2, 10, [6, 1 | <<22>>], 0 | 1]) 
{:ok, 21}
```