### PR TITLE
Use CQRS For The Storage Engine

### DIFF
--- a/lib/anoma/dump.ex
+++ b/lib/anoma/dump.ex
@@ -161,6 +161,7 @@ defmodule Anoma.Dump do
             router: Id.Extern.t(),
             mempool_topic: Id.Extern.t(),
             executor_topic: Id.Extern.t(),
+            storage_topic: Id.Extern.t(),
             logger: log_eng,
             clock: clock_eng,
             ordering: ord_eng,
@@ -196,6 +197,7 @@ defmodule Anoma.Dump do
             router: Id.Extern.t(),
             mempool_topic: Id.Extern.t(),
             executor_topic: Id.Extern.t(),
+            storage_topic: Id.Extern.t(),
             logger: log_eng,
             clock: clock_eng,
             ordering: ord_eng,
@@ -215,6 +217,7 @@ defmodule Anoma.Dump do
           :router,
           :mempool_topic,
           :executor_topic,
+          :storage_topic,
           :__struct__
         ]
       end)
@@ -232,7 +235,8 @@ defmodule Anoma.Dump do
       %{
         router: router.id,
         mempool_topic: state.mempool_topic.id,
-        executor_topic: state.executor_topic.id
+        executor_topic: state.executor_topic.id,
+        storage_topic: state.storage_topic.id
       },
       map
     )

--- a/lib/anoma/identity/manager.ex
+++ b/lib/anoma/identity/manager.ex
@@ -75,15 +75,12 @@ defmodule Anoma.Identity.Manager do
   3. One can no longer connect to the key given it does not exist in
      the system anymore
   """
-  @spec delete(Id.Extern.t(), Backend.t()) :: resp(nil)
+  @spec delete(Id.Extern.t(), Backend.t()) :: :ok
   def delete(id, mem = %Backend.Memory{}) do
     salted_key = Id.salt_keys(id, mem.symmetric)
-    res = Storage.delete_key(mem.storage, storage_key(salted_key.sign))
+    key = salted_key.sign |> storage_key()
 
-    case res do
-      {:atomic, :ok} -> {:ok, nil}
-      _ -> {:error, "bad transaction, failed to delete key"}
-    end
+    mem.storage |> Storage.delete_key(key)
   end
 
   ############################################################

--- a/lib/anoma/identity/signs_for.ex
+++ b/lib/anoma/identity/signs_for.ex
@@ -24,10 +24,7 @@ defmodule Anoma.Identity.SignsFor do
           :absent -> MapSet.new([trusted_key])
         end
 
-      case Storage.put(tab, key_space, new_set) do
-        {:atomic, :ok} -> :ok
-        _ -> :could_not_update_storage
-      end
+      Storage.put(tab, key_space, new_set)
     else
       :key_not_verified
     end

--- a/lib/anoma/node.ex
+++ b/lib/anoma/node.ex
@@ -48,6 +48,7 @@ defmodule Anoma.Node do
     field(:clock, Router.addr())
     field(:logger, Router.addr())
     field(:storage, Router.addr())
+    field(:storage_topic, Router.addr())
   end
 
   @type configuration() :: [
@@ -126,12 +127,14 @@ defmodule Anoma.Node do
 
     {:ok, router} = start_router(args[:router])
 
+    {:ok, storage_topic} = new_topic(router, args[:storage_topic])
+
     {:ok, storage} =
       start_engine(
         router,
         Storage,
         storage_id,
-        %Storage{storage_st | namespace: [router.id]}
+        %Storage{storage_st | namespace: [router.id], topic: storage_topic}
       )
 
     {:ok, clock} =
@@ -204,7 +207,8 @@ defmodule Anoma.Node do
        logger: logger,
        executor_topic: executor_topic,
        mempool_topic: mempool_topic,
-       storage: storage
+       storage: storage,
+       storage_topic: storage_topic
      }}
   end
 

--- a/lib/anoma/node/executor/worker.ex
+++ b/lib/anoma/node/executor/worker.ex
@@ -123,7 +123,7 @@ defmodule Anoma.Node.Executor.Worker do
   end
 
   @spec snapshot(Router.addr(), Nock.t()) ::
-          {:aborted, any()} | {:atomic, :ok}
+          :ok | nil
   def snapshot(storage, env) do
     snapshot = hd(env.snapshot_path)
     log_info({:snap, {storage, snapshot}, env.logger})

--- a/lib/anoma/node/storage.ex
+++ b/lib/anoma/node/storage.ex
@@ -75,9 +75,10 @@ defmodule Anoma.Node.Storage do
   """
   typedstruct do
     field(:qualified, atom(), default: Anoma.Node.Storage.Qualified)
-    field(:order, atom(), default: Anoma.Node.Storage.Order)
+    field(:order, atom(), default: Anoma.Node.Storage.Orderd)
     field(:rm_commitments, atom(), default: Anoma.Node.Storage.RMCommitments)
     field(:namespace, list(binary()), default: [])
+    field(:topic, Router.Addr.t(), enforce: false)
   end
 
   @type result(res) :: {:atomic, res} | {:aborted, any()}
@@ -107,7 +108,8 @@ defmodule Anoma.Node.Storage do
       qualified: opts[:qualified] || return.qualified,
       order: opts[:order] || return.order,
       rm_commitments: opts[:rm_commitments] || return.rm_commitments,
-      namespace: opts[:namespace] || return.namespace
+      namespace: opts[:namespace] || return.namespace,
+      topic: opts[:topic] || return.namespace
     }
 
     # idempotent
@@ -130,20 +132,19 @@ defmodule Anoma.Node.Storage do
   I will try to setup all values of storage, even if the first one
   fails due to already being setup, we will try the others.
   """
-  @spec remove(Router.Addr.t()) :: :ok | {:aborted, any()}
+  @spec remove(Router.Addr.t()) :: :ok
   def remove(storage = %Router.Addr{}) do
-    Router.call(storage, :remove)
+    Router.cast(storage, :remove)
   end
 
-  @spec setup(Router.Addr.t()) :: :ok | {:aborted, any()}
+  @spec setup(Router.Addr.t()) :: :ok
   def setup(t = %Router.Addr{}) do
-    Router.call(t, :setup)
+    Router.cast(t, :setup)
   end
 
-  @spec ensure_new(Router.Addr.t(), boolean()) :: :ok | {:aborted, any()}
-  @spec ensure_new(Anoma.Node.Router.Addr.t()) :: :ok | {:aborted, any()}
+  @spec ensure_new(Router.Addr.t(), boolean()) :: :ok
   def ensure_new(storage = %Router.Addr{}, rocks \\ false) do
-    Router.call(storage, {:ensure_new, rocks})
+    Router.cast(storage, {:ensure_new, rocks})
   end
 
   @spec get(Router.Addr.t(), order_key()) ::
@@ -152,14 +153,14 @@ defmodule Anoma.Node.Storage do
     Router.call(storage, {:get, key})
   end
 
-  @spec put(Router.Addr.t(), order_key(), qualified_value()) :: result(:ok)
+  @spec put(Router.Addr.t(), order_key(), qualified_value()) :: :ok
   def put(storage = %Router.Addr{}, key, value) do
-    Router.call(storage, {:put, key, value})
+    Router.cast(storage, {:put, key, value})
   end
 
-  @spec delete_key(Router.Addr.t(), order_key()) :: result(:ok)
+  @spec delete_key(Router.Addr.t(), order_key()) :: :ok
   def delete_key(storage = %Router.Addr{}, key) do
-    Router.call(storage, {:delete, key})
+    Router.cast(storage, {:delete, key})
   end
 
   @spec write_at_order_tx(
@@ -168,9 +169,9 @@ defmodule Anoma.Node.Storage do
           Noun.t(),
           non_neg_integer()
         ) ::
-          result(:ok)
+          :ok
   def write_at_order_tx(storage = %Router.Addr{}, key, value, order) do
-    Router.call(storage, {:write_at_order_tx, key, value, order})
+    Router.cast(storage, {:write_at_order_tx, key, value, order})
   end
 
   @spec blocking_read(Router.Addr.t(), qualified_key()) ::
@@ -264,11 +265,21 @@ defmodule Anoma.Node.Storage do
     end
   end
 
-  @spec do_remove(t()) :: :ok | {:aborted, any()}
+  @spec do_remove(t()) :: [:ok] | nil
   defp do_remove(storage = %__MODULE__{}) do
-    :mnesia.delete_table(storage.qualified)
-    :mnesia.delete_table(storage.order)
-    :mnesia.delete_table(storage.rm_commitments)
+    topic = storage.topic
+    del_q = :mnesia.delete_table(storage.qualified)
+    del_o = :mnesia.delete_table(storage.order)
+    del_c = :mnesia.delete_table(storage.rm_commitments)
+
+    unless topic == nil do
+      [
+        {:delete_qualified, del_q},
+        {:delete_ordering, del_o},
+        {:delete_commitments, del_c}
+      ]
+      |> Enum.map(fn x -> Router.cast(topic, x) end)
+    end
   end
 
   ############################################################
@@ -284,7 +295,7 @@ defmodule Anoma.Node.Storage do
     end
   end
 
-  @spec do_put(t(), order_key(), qualified_value()) :: result(:ok)
+  @spec do_put(t(), order_key(), qualified_value()) :: :ok | nil
   defp do_put(storage = %__MODULE__{}, key, value) do
     tx = fn ->
       order = read_order(storage, key)
@@ -293,10 +304,16 @@ defmodule Anoma.Node.Storage do
       instrument({:put_order, new_order})
     end
 
-    :mnesia.transaction(tx)
+    topic = storage.topic
+    mtx = :mnesia.transaction(tx)
+    msg = {:put, key, value} |> Tuple.append(mtx)
+
+    unless topic == nil do
+      storage.topic |> Router.cast(msg)
+    end
   end
 
-  @spec do_delete_key(t(), order_key()) :: result(:ok)
+  @spec do_delete_key(t(), order_key()) :: :ok | nil
   defp do_delete_key(storage = %__MODULE__{}, key) do
     instrument({:delete_key, key})
     do_put(storage, key, :absent)
@@ -369,16 +386,16 @@ defmodule Anoma.Node.Storage do
     end)
   end
 
-  @spec put_snapshot(t(), order_key()) :: result(:ok)
+  @spec put_snapshot(t(), order_key()) :: :ok | nil
   def put_snapshot(storage = %__MODULE__{}, key) do
     with {:atomic, snapshot} <- do_snapshot_order(storage) do
       do_put(storage, key, snapshot)
     end
   end
 
-  @spec put_snapshot(Router.addr(), order_key()) :: result(:ok)
+  @spec put_snapshot(Router.addr(), order_key()) :: :ok
   def put_snapshot(storage = %Router.Addr{}, key) do
-    Router.call(storage, {:put_snapshot, key})
+    Router.cast(storage, {:put_snapshot, key})
   end
 
   @spec in_snapshot(snapshot(), order_key()) :: nil | non_neg_integer()
@@ -512,10 +529,16 @@ defmodule Anoma.Node.Storage do
           qualified_value(),
           non_neg_integer()
         ) ::
-          result(:ok)
+          :ok | nil
   defp do_write_at_order_tx(storage = %__MODULE__{}, key, value, order) do
     tx = fn -> write_at_order(storage, key, value, order) end
-    :mnesia.transaction(tx)
+    mtx = :mnesia.transaction(tx)
+    msg = {:write, key, value, order} |> Tuple.append(mtx)
+    topic = storage.topic
+
+    unless topic == nil do
+      storage.topic |> Router.cast(msg)
+    end
   end
 
   ############################################################
@@ -637,40 +660,47 @@ defmodule Anoma.Node.Storage do
     {:reply, state, state}
   end
 
-  def handle_call(:setup, _, t) do
-    {:reply, do_setup(t), t}
+  def handle_cast(:setup, _, t) do
+    do_setup(t)
+    {:noreply, t}
   end
 
-  def handle_call(:remove, _, storage) do
-    {:reply, do_remove(storage), storage}
+  def handle_cast(:remove, _, storage) do
+    do_remove(storage)
+    {:noreply, storage}
   end
 
   def handle_call({:get, key}, _, storage) do
     {:reply, do_get(storage, key), storage}
   end
 
-  def handle_call({:ensure_new, rocks}, _, storage) do
-    {:reply, do_ensure_new(storage, rocks), storage}
+  def handle_cast({:ensure_new, rocks}, _, storage) do
+    do_ensure_new(storage, rocks)
+    {:noreply, storage}
   end
 
-  def handle_call({:put_snapshot, key}, _, storage) do
-    {:reply, put_snapshot(storage, key), storage}
+  def handle_cast({:put_snapshot, key}, _, storage) do
+    put_snapshot(storage, key)
+    {:noreply, storage}
   end
 
-  def handle_call({:put, key, value}, _, storage) do
-    {:reply, do_put(storage, key, value), storage}
+  def handle_cast({:put, key, value}, _, storage) do
+    do_put(storage, key, value)
+    {:noreply, storage}
   end
 
-  def handle_call({:delete, key}, _, storage) do
-    {:reply, do_delete_key(storage, key), storage}
+  def handle_cast({:delete, key}, _, storage) do
+    do_delete_key(storage, key)
+    {:noreply, storage}
   end
 
   def handle_call({:read_order_tx, key}, _, storage) do
     {:reply, do_read_order_tx(storage, key), storage}
   end
 
-  def handle_call({:write_at_order_tx, key, value, order}, _, storage) do
-    {:reply, do_write_at_order_tx(storage, key, value, order), storage}
+  def handle_cast({:write_at_order_tx, key, value, order}, _, storage) do
+    do_write_at_order_tx(storage, key, value, order)
+    {:noreply, storage}
   end
 
   def handle_call({:get_keyspace, key_space}, _, storage) do

--- a/test/node/end_test.exs
+++ b/test/node/end_test.exs
@@ -28,7 +28,7 @@ defmodule AnomaTest.Node.End do
           [
             snapshot_path: snapshot_path,
             storage_data: storage,
-            block_storage: :mempool_blocks,
+            block_storage: :end_blocks,
             ping_time: :no_timer
           ]
           |> Anoma.Node.start_min()
@@ -70,7 +70,7 @@ defmodule AnomaTest.Node.End do
       )
 
     assert {:ok, 1} = Mempool.execute(mempool)
-    assert_receive {:"$gen_cast", {_, _, {:process_done, ^pid_zero}}}
+    assert_receive({:"$gen_cast", {_, _, {:process_done, ^pid_zero}}}, 5000)
 
     keya = Sign.new_keypair()
     keyb = Sign.new_keypair()

--- a/test/node/mempool_test.exs
+++ b/test/node/mempool_test.exs
@@ -57,9 +57,9 @@ defmodule AnomaTest.Node.Mempool do
     pid_two = Mempool.tx(node.mempool, {:kv, increment}).pid
 
     Mempool.execute(node.mempool)
-    assert_receive {:"$gen_cast", {_, _, {:process_done, ^pid_zero}}}
-    assert_receive {:"$gen_cast", {_, _, {:process_done, ^pid_one}}}
-    assert_receive {:"$gen_cast", {_, _, {:process_done, ^pid_two}}}
+    assert_receive({:"$gen_cast", {_, _, {:process_done, ^pid_zero}}}, 5000)
+    assert_receive({:"$gen_cast", {_, _, {:process_done, ^pid_one}}}, 5000)
+    assert_receive({:"$gen_cast", {_, _, {:process_done, ^pid_two}}}, 5000)
     assert {:ok, 2} = Storage.get(storage, key)
 
     :ok =
@@ -86,8 +86,8 @@ defmodule AnomaTest.Node.Mempool do
     pid_two = Mempool.tx(node.mempool, {:kv, increment}).pid
 
     Mempool.execute(node.mempool)
-    assert_receive {:"$gen_cast", {_, _, {:process_done, ^pid_one}}}
-    assert_receive {:"$gen_cast", {_, _, {:process_done, ^pid_two}}}
+    assert_receive({:"$gen_cast", {_, _, {:process_done, ^pid_one}}}, 5000)
+    assert_receive({:"$gen_cast", {_, _, {:process_done, ^pid_two}}}, 5000)
     assert :absent = Storage.get(storage, key)
 
     :ok =

--- a/test/node/pinger_test.exs
+++ b/test/node/pinger_test.exs
@@ -67,9 +67,9 @@ defmodule AnomaTest.Node.Pinger do
     pid_one = Mempool.tx(node.mempool, {:kv, increment}).pid
     pid_two = Mempool.tx(node.mempool, {:kv, increment}).pid
 
-    assert_receive {:"$gen_cast", {_, _, {:process_done, ^pid_zero}}}
-    assert_receive {:"$gen_cast", {_, _, {:process_done, ^pid_one}}}
-    assert_receive {:"$gen_cast", {_, _, {:process_done, ^pid_two}}}
+    assert_receive({:"$gen_cast", {_, _, {:process_done, ^pid_zero}}}, 5000)
+    assert_receive({:"$gen_cast", {_, _, {:process_done, ^pid_one}}}, 5000)
+    assert_receive({:"$gen_cast", {_, _, {:process_done, ^pid_two}}}, 5000)
 
     assert {:ok, 2} = Storage.get(storage, key)
 

--- a/test/node/storage_test.exs
+++ b/test/node/storage_test.exs
@@ -134,7 +134,7 @@ defmodule AnomaTest.Node.Storage do
 
       assert Process.alive?(waiting)
       Ordering.new_order(ordering, [Order.new(1, <<1>>, waiting)])
-      assert_receive {:received, 1}
+      assert_receive({:received, 1}, 5000)
     end
 
     test "properly get snapshot from id", %{ordering: ordering} do

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -7,19 +7,21 @@ defmodule AnomaTest.Storage do
   doctest(Anoma.Node.Storage)
 
   setup_all do
-    # base storage testing default
+    {:ok, router} = Router.start()
+
+    {:ok, topic} = Router.new_topic(router)
+
     storage = %Storage{
       qualified: AnomaTest.Storage.Qualified,
-      order: AnomaTest.Storage.Order
+      order: AnomaTest.Storage.Order,
+      topic: topic
     }
-
-    {:ok, router} = Router.start()
 
     {:ok, storage} =
       Router.start_engine(router, Storage, storage)
 
     Storage.ensure_new(storage)
-    [storage: storage]
+    [storage: storage, router: router, topic: topic]
   end
 
   describe "Direct API" do
@@ -28,46 +30,121 @@ defmodule AnomaTest.Storage do
       assert Storage.get(storage, testing_atom) == :absent
     end
 
-    test "Putting works", %{storage: storage} do
+    test "Putting works", %{storage: storage, router: router, topic: topic} do
       testing_atom = :QWERTZ_putting
-      assert {:atomic, :ok} = Storage.put(storage, testing_atom, 1)
+
+      :ok = Router.call(router, {:subscribe_topic, topic, :local})
+
+      Storage.put(storage, testing_atom, 1)
+
       assert {:ok, 1} = Storage.get(storage, testing_atom)
+
+      assert_receive {:"$gen_cast",
+                      {:router_cast, _,
+                       {:put, ^testing_atom, 1, {:atomic, :ok}}}}
+
+      :ok = Router.call(router, {:unsubscribe_topic, topic, :local})
     end
 
-    test "Deleting key works", %{storage: storage} do
+    test "Deleting key works", %{
+      storage: storage,
+      router: router,
+      topic: topic
+    } do
       testing_atom = :QWERTZ_delete
-      assert {:atomic, :ok} = Storage.put(storage, testing_atom, 1)
-      assert {:atomic, :ok} = Storage.put(storage, testing_atom, 2)
+
+      :ok = Router.call(router, {:subscribe_topic, topic, :local})
+
+      Storage.put(storage, testing_atom, 1)
+      Storage.put(storage, testing_atom, 2)
+
       assert {:ok, 2} = Storage.get(storage, testing_atom)
-      assert {:atomic, :ok} = Storage.delete_key(storage, testing_atom)
+
+      assert_receive {:"$gen_cast",
+                      {:router_cast, _,
+                       {:put, ^testing_atom, 1, {:atomic, :ok}}}}
+
+      assert_receive {:"$gen_cast",
+                      {:router_cast, _,
+                       {:put, ^testing_atom, 2, {:atomic, :ok}}}}
+
+      Storage.delete_key(storage, testing_atom)
+
       assert :absent = Storage.get(storage, testing_atom)
+
+      assert_receive {:"$gen_cast",
+                      {:router_cast, _,
+                       {:put, ^testing_atom, :absent, {:atomic, :ok}}}}
+
+      :ok = Router.call(router, {:unsubscribe_topic, topic, :local})
     end
 
-    test "Deleting key again", %{storage: storage} do
+    test "Deleting key again", %{
+      storage: storage,
+      router: router,
+      topic: topic
+    } do
       testing_atom = :QWERTZ_delete
-      assert {:atomic, :ok} = Storage.put(storage, testing_atom, 1)
-      assert {:atomic, :ok} = Storage.put(storage, testing_atom, 2)
+
+      :ok = Router.call(router, {:subscribe_topic, topic, :local})
+
+      Storage.put(storage, testing_atom, 1)
+      Storage.put(storage, testing_atom, 2)
+
       assert {:ok, 2} = Storage.get(storage, testing_atom)
-      assert {:atomic, :ok} = Storage.delete_key(storage, testing_atom)
-      assert {:atomic, :ok} = Storage.delete_key(storage, testing_atom)
+
+      assert_receive {:"$gen_cast",
+                      {:router_cast, _,
+                       {:put, ^testing_atom, 1, {:atomic, :ok}}}}
+
+      assert_receive {:"$gen_cast",
+                      {:router_cast, _,
+                       {:put, ^testing_atom, 2, {:atomic, :ok}}}}
+
+      Storage.delete_key(storage, testing_atom)
+      Storage.delete_key(storage, testing_atom)
+
       assert :absent = Storage.get(storage, testing_atom)
+
+      assert_receive {:"$gen_cast",
+                      {:router_cast, _,
+                       {:put, ^testing_atom, :absent, {:atomic, :ok}}}}
+
+      :ok = Router.call(router, {:unsubscribe_topic, topic, :local})
     end
 
-    test "block_reads work", %{storage: storage} do
+    test "block_reads work", %{storage: storage, router: router, topic: topic} do
       testing_atom = :QWERTZ_blocking
-      assert {:atomic, :ok} = Storage.put(storage, testing_atom, 1)
+
+      :ok = Router.call(router, {:subscribe_topic, topic, :local})
+
+      Storage.put(storage, testing_atom, 1)
 
       assert {:ok, block} =
                Storage.blocking_read(storage, [1, testing_atom | 0])
 
       assert {:ok, current} = Storage.get(storage, testing_atom)
+
+      assert_receive {:"$gen_cast",
+                      {:router_cast, _,
+                       {:put, ^testing_atom, 1, {:atomic, :ok}}}}
+
       assert current == block
+
+      :ok = Router.call(router, {:unsubscribe_topic, topic, :local})
     end
 
-    test "block_reads can read the past", %{storage: storage} do
+    test "block_reads can read the past", %{
+      storage: storage,
+      router: router,
+      topic: topic
+    } do
       testing_atom = :QWERTZ_blocking_past
-      assert {:atomic, :ok} = Storage.put(storage, testing_atom, 1)
-      assert {:atomic, :ok} = Storage.put(storage, testing_atom, 2)
+
+      :ok = Router.call(router, {:subscribe_topic, topic, :local})
+
+      Storage.put(storage, testing_atom, 1)
+      Storage.put(storage, testing_atom, 2)
 
       assert {:ok, bl_1} =
                Storage.blocking_read(storage, [1, testing_atom | 0])
@@ -76,8 +153,19 @@ defmodule AnomaTest.Storage do
                Storage.blocking_read(storage, [2, testing_atom | 0])
 
       assert {:ok, curr} = Storage.get(storage, testing_atom)
+
+      assert_receive {:"$gen_cast",
+                      {:router_cast, _,
+                       {:put, ^testing_atom, 1, {:atomic, :ok}}}}
+
+      assert_receive {:"$gen_cast",
+                      {:router_cast, _,
+                       {:put, ^testing_atom, 2, {:atomic, :ok}}}}
+
       assert curr == bl_2
       assert bl_1 + 1 == bl_2
+
+      :ok = Router.call(router, {:unsubscribe_topic, topic, :local})
     end
 
     test "blocking_reads must accept position indicators", %{storage: s} do
@@ -99,6 +187,7 @@ defmodule AnomaTest.Storage do
       assert Process.alive?(pid) == true
       Storage.put(storage, testing_atom, 1)
       assert_receive {:read, 1}, 100
+      assert Process.alive?(pid) == false
     end
   end
 
@@ -152,22 +241,54 @@ defmodule AnomaTest.Storage do
   end
 
   describe "Snapshots" do
-    test "snapshots properly put", %{storage: storage} do
+    test "snapshots properly put", %{
+      storage: storage,
+      router: router,
+      topic: topic
+    } do
       snapshot_storage = :snapshot_super_secret
-      assert {:atomic, :ok} = Storage.put_snapshot(storage, snapshot_storage)
+
+      :ok = Router.call(router, {:subscribe_topic, topic, :local})
+
+      Storage.put_snapshot(storage, snapshot_storage)
       assert {:ok, _} = Storage.get(storage, snapshot_storage)
+
+      assert_receive {:"$gen_cast",
+                      {:router_cast, _,
+                       {:put, ^snapshot_storage, _, {:atomic, :ok}}}}
+
+      :ok = Router.call(router, {:unsubscribe_topic, topic, :local})
     end
 
-    test "snapshots properly get the latest", %{storage: storage} do
+    test "snapshots properly get the latest", %{
+      storage: storage,
+      router: router,
+      topic: topic
+    } do
       snapshot_storage = :super_hot
       testing_atom = 111_222_333_444_555_666
+
+      :ok = Router.call(router, {:subscribe_topic, topic, :local})
+
       Storage.write_at_order_tx(storage, testing_atom, 10, 3)
-      assert {:atomic, :ok} = Storage.put_snapshot(storage, snapshot_storage)
+      Storage.put_snapshot(storage, snapshot_storage)
+
+      assert_receive {:"$gen_cast",
+                      {:router_cast, _,
+                       {:write, ^testing_atom, 10, 3, {:atomic, :ok}}}}
+
+      assert_receive {:"$gen_cast",
+                      {:router_cast, _,
+                       {:put, ^snapshot_storage, _, {:atomic, :ok}}}}
+
       assert {:ok, snapshot} = Storage.get(storage, snapshot_storage)
+
       assert Storage.in_snapshot(snapshot, testing_atom) == 3
 
       assert Storage.get_at_snapshot(snapshot, testing_atom) ==
                {:ok, 10}
+
+      :ok = Router.call(router, {:unsubscribe_topic, topic, :local})
     end
 
     test "missing key gives us nil", %{storage: storage} do


### PR DESCRIPTION
Implements CQRS for the Storage Engine implementation. All functionality changing a given mnesia table is made into a cast.

Changes corresponding codebase in the following manner:

1. The Identity modules matching on `put` outputs now just use the `put` functionality and hence produce no error messages on `:aborted`.

2. Instead, we use the topic functionality. Introducing topics into all necessary modules such as Node and Dump.

3. Change storage tests to listen to broadcasts instead of matching on Storage messages.

4. Add timeout options for asserting reception in the test due to casting not blocking as calls before did.

5. Fix typing