### PR TITLE
use regular binary_to_term for loading snapshots

### DIFF
--- a/lib/anoma/dump.ex
+++ b/lib/anoma/dump.ex
@@ -114,7 +114,7 @@ defmodule Anoma.Dump do
   @spec load(String.t()) :: any()
   def load(name) do
     with {:ok, bin} <- File.read(name) do
-      Plug.Crypto.non_executable_binary_to_term(bin)
+      :erlang.binary_to_term(bin)
     end
   end
 


### PR DESCRIPTION
I don't think there's an interesting application for loading untrusted snapshots.  And disallowing executables means I can't dump an IdentityMap