### PR TITLE
Set the home directory to be just anoma, allow multiple applications

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -5,7 +5,7 @@ config :logger,
   handle_otp_reports: true,
   handle_sasl_reports: true
 
-app = ~c"anoma_#{Mix.env()}"
+app = ~c"anoma"
 
 data = :filename.basedir(:user_data, app) |> List.to_string()
 config = :filename.basedir(:user_config, app) |> List.to_string()
@@ -20,8 +20,10 @@ unless env == :test do
   File.mkdir_p!(data)
   File.mkdir_p!(config)
 
-  config :mnesia,
-    dir: ~c"#{data}"
+  if env == :prod do
+    config :mnesia,
+      dir: ~c"#{data}"
+  end
 end
 
 import_config "#{config_env()}.exs"


### PR DESCRIPTION
In this commit we do two things:

1. Set the home to be anoma, not anoma_iex, anoma_prod, anoma_dev, etc.

This means that the dump files and socket files in the transport code will use the same directory for retreiving things.

This is what we really want anyways, as this is a dev only convention users would not see, and it's quite frankly not helping engineering. The fact I have to symlink causes a mess of issues when setting up an easy copy and patse environments

2. We don't set the mnesia data dir

This means by default it choses the hostname of the current node, like

Mnesia.mariari@Gensokyo

being a directory.

What is nice, is that unless you are trying to run the prod node, this is the default.

The user binary should always be prod, and thus there should be one cannonical DB, for all other envs, we should just spawn up a fresh one, load the DΒ as needed... fairly common sense no?

This combined with 1. means that we can spawn the same environment and just load the environment and we can send messages across anoma instances