### PR TITLE
High restart rate for children of the router

### DIFF
--- a/lib/anoma/node/router.ex
+++ b/lib/anoma/node/router.ex
@@ -289,7 +289,12 @@ defmodule Anoma.Node.Router do
     supervisor = process_name(:supervisor, id.external)
 
     {:ok, _} =
-      DynamicSupervisor.start_link(name: supervisor, strategy: :one_for_one)
+      DynamicSupervisor.start_link(
+        name: supervisor,
+        strategy: :one_for_one,
+        max_restarts: 10_000_000,
+        max_seconds: 1
+      )
 
     router = process_name(__MODULE__, id.external)
 


### PR DESCRIPTION
This allows the children of the router to die 10_000_000 times every second before the router itself dies and restarts.

This will currently be used for the TcpConnection, we should remove this in time, as children should not be dying often