### PR TITLE
Make Engine's respect children's child_spec

### DIFF
--- a/lib/anoma/node/intent_pool.ex
+++ b/lib/anoma/node/intent_pool.ex
@@ -1,6 +1,4 @@
 defmodule Anoma.Node.IntentPool do
-  use GenServer
-
   @moduledoc """
 
   """

--- a/lib/anoma/node/router.ex
+++ b/lib/anoma/node/router.ex
@@ -228,7 +228,7 @@ defmodule Anoma.Node.Router do
   indeed differ from the diagram.
 
   """
-  use GenServer
+  use Anoma.Node.Router.Engine
   use TypedStruct
   require Logger
 

--- a/lib/anoma/node/router/engine.ex
+++ b/lib/anoma/node/router/engine.ex
@@ -7,8 +7,9 @@ defmodule Anoma.Node.Router.Engine do
   alias Anoma.Crypto.Id
   alias Anoma.Node.Router
 
-  defmacro __using__(_) do
+  defmacro __using__(opts) do
     quote do
+      use GenServer, unquote(opts)
     end
   end
 
@@ -139,5 +140,13 @@ defmodule Anoma.Node.Router.Engine do
       err ->
         err
     end
+  end
+
+  def child_spec(argument = {_router, mod, _id, arg}) do
+    mod.child_spec(arg)
+    |> Map.merge(%{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [argument]}
+    })
   end
 end

--- a/lib/anoma/node/storage.ex
+++ b/lib/anoma/node/storage.ex
@@ -63,6 +63,7 @@ defmodule Anoma.Node.Storage do
   alias __MODULE__
 
   use TypedStruct
+  use Router.Engine
 
   require Logger
 


### PR DESCRIPTION
Before the engine would just use it's own childspec.

This would cause issues with engines that we wished to kill... TCPConnections are a good example, because if they die normally they should not be restarted. Thus we make using Anoma.Node.Router.Engine actually use Genserver.

Further we pass the argument so we can something like

  use Router.Engine, restart: :transient

Which means that they can have the transient child_spec by default meaning that the engine will just inherit these properties