### PR TITLE
Run some logic after the transport engine is finished running

### DIFF
--- a/test/node/transport_test.exs
+++ b/test/node/transport_test.exs
@@ -34,12 +34,17 @@ defmodule AnomaTest.Node.Transport do
 
     socket_name = :enacl.randombytes(8) |> Base.encode64()
 
-    socket_addr = {:unix, Anoma.System.Directories.data(socket_name)}
+    socket_dir = Anoma.System.Directories.data(socket_name)
+    socket_addr = {:unix, socket_dir}
 
     Transport.start_server(
       node.transport,
-      {:unix, Anoma.System.Directories.data(socket_name)}
+      {:unix, socket_dir}
     )
+
+    on_exit(fn ->
+      File.rm(socket_dir)
+    end)
 
     [
       node: node,


### PR DESCRIPTION
This meakes sure that when tests are ran, it does not fill up the directory with dead scoket files