### PR TITLE
Change Default Config Dump Path to XDG Format

### DIFF
--- a/lib/anoma/configuration.ex
+++ b/lib/anoma/configuration.ex
@@ -40,7 +40,7 @@ defmodule Anoma.Configuration do
   ############################################################
 
   @dump_format [
-    {"dump", &is_binary/1, "anoma_#{Mix.env()}.dmp"}
+    {"dump", &is_binary/1, "anoma_#{Mix.env()}.dmp" |> Directories.data()}
   ]
   @node_format [
     {"block_storage", &is_binary/1, "anoma_block"},


### PR DESCRIPTION
When default config is fed into the application startup, instead of just a name feed a full path as specified by XDG format using the Directories module.

Fixes #480 