### PR TITLE
Remove dialyzer suppression attributes

### DIFF
--- a/lib/anoma/cli.ex
+++ b/lib/anoma/cli.ex
@@ -134,8 +134,6 @@ defmodule Anoma.Cli do
     end
   end
 
-  # Optimus.t() is opaque so the help fails to type check, but it's OK
-  @dialyzer {:nowarn_function, top_level_help: 0}
   def top_level_help() do
     IO.puts(Optimus.help(Anoma.Cli.argument_parser()))
   end

--- a/lib/anoma/dump.ex
+++ b/lib/anoma/dump.ex
@@ -91,7 +91,6 @@ defmodule Anoma.Dump do
   relaunch the executions as well.
   """
 
-  @dialyzer {:no_return, launch: 2}
   @spec launch(String.t(), atom()) :: {:ok, %Node{}} | any()
   def launch(file, name) do
     load = file |> load()
@@ -113,7 +112,6 @@ defmodule Anoma.Dump do
   named supervisor.
   """
 
-  @dialyzer {:no_return, launch: 2}
   @spec launch(String.t(), atom(), atom(), Configuration.configuration_map()) ::
           {:ok, %Node{}} | any()
   def launch(file, name, sup_name, config) do

--- a/lib/nock.ex
+++ b/lib/nock.ex
@@ -34,8 +34,6 @@ defmodule Nock do
     field(:logger, Router.Addr.t(), enforce: false)
   end
 
-  @dialyzer :no_improper_lists
-
   @layers 6
 
   @layer_1_context_mug 17_654_928_022_549_292_273

--- a/lib/noun.ex
+++ b/lib/noun.ex
@@ -5,8 +5,6 @@ defmodule Noun do
   Represented as Elixir cons cells, which might get annoying.
   """
 
-  @dialyzer :no_improper_lists
-
   require Integer
 
   @type noun_atom() :: non_neg_integer() | binary() | []

--- a/lib/noun/format.ex
+++ b/lib/noun/format.ex
@@ -3,8 +3,6 @@ defmodule Noun.Format do
   Parsing and printing of nouns.
   """
 
-  @dialyzer :no_improper_lists
-
   @spec parse_always(String.t()) :: Noun.t()
   def parse_always(string) do
     {:ok, parsed} = parse(string)


### PR DESCRIPTION
The removed suppression attributes have no effect with OTP 27 / Elixir 1.17.0

Closes anoma/anoma-archive#1267 