### PR TITLE
Update Resource.kind to use jam

### DIFF
--- a/lib/anoma/resource.ex
+++ b/lib/anoma/resource.ex
@@ -70,12 +70,14 @@ defmodule Anoma.Resource do
     |> Sign.sign(secret)
   end
 
+  @spec kind(t()) :: binary()
   @doc """
   The kind of the given resource (labelled logic).
   """
   def kind(resource = %Resource{}) do
-    :erlang.term_to_binary(resource.logic) <>
-      :erlang.term_to_binary(resource.label)
+    [resource.logic | resource.label]
+    |> Nock.Jam.jam()
+    |> Noun.atom_integer_to_binary()
   end
 
   @doc """


### PR DESCRIPTION
Following on from c28de348c16 we want to use jam instead of :erlang.term_to_binary for serialization.

Exernal users of Anoma need to compute the kind when building a Transaction.