### PR TITLE
Alias Core Modules on Startup

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,5 @@
+alias Anoma.{Node, Block, Dump, Mnesia}
+alias Node.{Router, Transport, Ordering, Executor, Mempool, Pinger, Clock, Logger, Storage}
+alias Router.Engine
+
+import_file_if_available("~/.iex.exs")


### PR DESCRIPTION
Creates a local `.iex.exs` file for the Anoma repo. It aliases all core modules and engines commonly used in interactive environment and imports the global user config if availiable.