### PR TITLE
Fix anoma node configuration type and specs

### DIFF
--- a/documentation/logging.livemd
+++ b/documentation/logging.livemd
@@ -45,18 +45,18 @@ name = :loggerdoc
 snapshot_path = [:my_special_nock_snaphsot | 0]
 
 {:ok, nodes} =
-  Anoma.Node.start_link(
-    new_storage: true,
+  Anoma.Node.start_link_or_find_instance(
     name: name,
     use_rocks: false,
     settings:
-      [
-        snapshot_path: snapshot_path,
-        storage_data: storage,
-        block_storage: :loggerdoc_blocks,
-        ping_time: :no_timer
-      ]
-      |> Anoma.Node.start_min()
+      {:new_storage,
+       [
+         snapshot_path: snapshot_path,
+         storage_data: storage,
+         block_storage: :dump_blocks,
+         ping_time: :no_timer
+       ]
+       |> Anoma.Node.start_min()}
   )
 
 node = Anoma.Node.state(nodes)

--- a/lib/anoma/configuration.ex
+++ b/lib/anoma/configuration.ex
@@ -218,10 +218,9 @@ defmodule Anoma.Configuration do
     settings = Anoma.Node.start_min(node_settings)
 
     [
-      new_storage: true,
       name: Keyword.get(node_settings, :name),
       use_rocks: rocks_flag,
-      settings: settings,
+      settings: {:new_storage, settings},
       configuration: parsed_map
     ]
   end

--- a/lib/anoma/dump.ex
+++ b/lib/anoma/dump.ex
@@ -112,9 +112,8 @@ defmodule Anoma.Dump do
     settings = block_check(load)
 
     node_settings = [
-      new_storage: false,
       name: name,
-      settings: settings,
+      settings: {:from_dump, settings},
       use_rocks: load[:use_rocks]
     ]
 
@@ -135,9 +134,8 @@ defmodule Anoma.Dump do
     settings = block_check(load)
 
     node_settings = [
-      new_storage: false,
       name: name,
-      settings: settings,
+      settings: {:from_dump, settings},
       use_rocks: load[:use_rocks],
       configuration: config
     ]

--- a/test/node/dump_test.exs
+++ b/test/node/dump_test.exs
@@ -17,17 +17,17 @@ defmodule AnomaTest.Node.Dump do
 
     {:ok, nodes} =
       Anoma.Node.start_link_or_find_instance(
-        new_storage: true,
         name: name,
         use_rocks: false,
         settings:
-          [
-            snapshot_path: snapshot_path,
-            storage_data: storage,
-            block_storage: :dump_blocks,
-            ping_time: :no_timer
-          ]
-          |> Anoma.Node.start_min()
+          {:new_storage,
+           [
+             snapshot_path: snapshot_path,
+             storage_data: storage,
+             block_storage: :dump_blocks,
+             ping_time: :no_timer
+           ]
+           |> Anoma.Node.start_min()}
       )
 
     [nodes: nodes, name: name]

--- a/test/node/dumper_test.exs
+++ b/test/node/dumper_test.exs
@@ -22,19 +22,19 @@ defmodule AnomaTest.Node.Dumper do
 
     {:ok, nodes} =
       Anoma.Node.start_link(
-        new_storage: true,
         name: node_name,
         use_rocks: false,
         settings:
-          [
-            snapshot_path: snapshot_path,
-            storage_data: storage,
-            block_storage: :dumper_blocks,
-            ping_time: :no_timer,
-            configuration: config,
-            count: 1
-          ]
-          |> Anoma.Node.start_min()
+          {:new_storage,
+           [
+             snapshot_path: snapshot_path,
+             storage_data: storage,
+             block_storage: :dumper_blocks,
+             ping_time: :no_timer,
+             configuration: config,
+             count: 1
+           ]
+           |> Anoma.Node.start_min()}
       )
 
     node = Anoma.Node.state(nodes)

--- a/test/node/end_test.exs
+++ b/test/node/end_test.exs
@@ -21,17 +21,17 @@ defmodule AnomaTest.Node.End do
 
     {:ok, nodes} =
       Anoma.Node.start_link_or_find_instance(
-        new_storage: true,
         name: name,
         use_rocks: true,
         settings:
-          [
-            snapshot_path: snapshot_path,
-            storage_data: storage,
-            block_storage: :end_blocks,
-            ping_time: :no_timer
-          ]
-          |> Anoma.Node.start_min()
+          {:new_storage,
+           [
+             snapshot_path: snapshot_path,
+             storage_data: storage,
+             block_storage: :end_blocks,
+             ping_time: :no_timer
+           ]
+           |> Anoma.Node.start_min()}
       )
 
     node = Anoma.Node.state(nodes)

--- a/test/node/mempool_test.exs
+++ b/test/node/mempool_test.exs
@@ -18,17 +18,17 @@ defmodule AnomaTest.Node.Mempool do
 
     {:ok, nodes} =
       Anoma.Node.start_link_or_find_instance(
-        new_storage: true,
         name: name,
         use_rocks: false,
         settings:
-          [
-            snapshot_path: snapshot_path,
-            storage_data: storage,
-            block_storage: :mempool_blocks,
-            ping_time: :no_timer
-          ]
-          |> Anoma.Node.start_min()
+          {:new_storage,
+           [
+             snapshot_path: snapshot_path,
+             storage_data: storage,
+             block_storage: :mempool_blocks,
+             ping_time: :no_timer
+           ]
+           |> Anoma.Node.start_min()}
       )
 
     node = Anoma.Node.state(nodes)

--- a/test/node/pinger_test.exs
+++ b/test/node/pinger_test.exs
@@ -17,17 +17,17 @@ defmodule AnomaTest.Node.Pinger do
 
     {:ok, nodes} =
       Anoma.Node.start_link_or_find_instance(
-        new_storage: true,
         name: name,
         use_rocks: false,
         settings:
-          [
-            snapshot_path: snapshot_path,
-            storage_data: storage,
-            block_storage: :pinger_blocks,
-            ping_time: :no_timer
-          ]
-          |> Anoma.Node.start_min()
+          {:new_storage,
+           [
+             snapshot_path: snapshot_path,
+             storage_data: storage,
+             block_storage: :pinger_blocks,
+             ping_time: :no_timer
+           ]
+           |> Anoma.Node.start_min()}
       )
 
     node = Anoma.Node.state(nodes)

--- a/test/node/transport_test.exs
+++ b/test/node/transport_test.exs
@@ -16,16 +16,16 @@ defmodule AnomaTest.Node.Transport do
 
     {:ok, nodes} =
       Anoma.Node.start_link_or_find_instance(
-        new_storage: true,
         name: name,
         settings:
-          [
-            snapshot_path: snapshot_path,
-            storage_data: storage,
-            block_storage: :mempool_blocks,
-            ping_time: :no_timer
-          ]
-          |> Anoma.Node.start_min()
+          {:new_storage,
+           [
+             snapshot_path: snapshot_path,
+             storage_data: storage,
+             block_storage: :mempool_blocks,
+             ping_time: :no_timer
+           ]
+           |> Anoma.Node.start_min()}
       )
 
     node = Anoma.Node.state(nodes)


### PR DESCRIPTION
Anoma node settings are tupled with an atom matching on :new_storage / :from_dump