### PR TITLE
Make the pinger follow CQRS

### DIFF
--- a/lib/anoma/node.ex
+++ b/lib/anoma/node.ex
@@ -280,7 +280,8 @@ defmodule Anoma.Node do
         Pinger,
         %Pinger{
           ping_st
-          | mempool: mempool
+          | mempool: mempool,
+            logger: logger
         },
         id: ping_id
       )


### PR DESCRIPTION
The messages in the pinger were returning strings to denote how state updating happens, now they go through the logger.

Further since all messages were state changing every message became a cast rather than a call.