### PR TITLE
proof record: do not allow nil proof

### DIFF
--- a/lib/anoma/resource/proof_record.ex
+++ b/lib/anoma/resource/proof_record.ex
@@ -8,7 +8,7 @@ defmodule Anoma.Resource.ProofRecord do
   alias Anoma.Resource.Proof
 
   typedstruct enforce: true do
-    field(:proof, Proof.t(), default: nil)
+    field(:proof, Proof.t())
   end
 
   @spec prove(Resource.t()) :: t()


### PR DESCRIPTION
This was an error in the original version of this struct; a proof
record must contain at minimum a proof.
