### PR TITLE
Normalize noun before updating jam cache

### DIFF
--- a/lib/nock/jam.ex
+++ b/lib/nock/jam.ex
@@ -21,15 +21,23 @@ defmodule Nock.Jam do
 
   @spec encode(t(), Noun.t()) :: t()
   def encode(jam_env, noun) do
-    case Map.fetch(jam_env.cache, noun) do
+    case fetch_cache_noun(jam_env, noun) do
       {:ok, position} -> handle_back(jam_env, position, noun)
-      :error -> jam_env |> cache_term(noun) |> write(noun)
+      :error -> jam_env |> cache_noun(noun) |> write(noun)
     end
   end
 
-  @spec cache_term(t(), Noun.t()) :: t()
-  def cache_term(env = %__MODULE__{}, noun) do
-    %__MODULE__{env | cache: Map.put(env.cache, noun, env.position)}
+  @spec cache_noun(t(), Noun.t()) :: t()
+  def cache_noun(env = %__MODULE__{}, noun) do
+    %__MODULE__{
+      env
+      | cache: Map.put(env.cache, Noun.normalize_noun(noun), env.position)
+    }
+  end
+
+  @spec fetch_cache_noun(t(), Noun.t()) :: {:ok, non_neg_integer()} | :error
+  def fetch_cache_noun(env, noun) do
+    Map.fetch(env.cache, Noun.normalize_noun(noun))
   end
 
   @spec handle_back(t(), non_neg_integer(), Noun.t()) :: t()

--- a/lib/noun.ex
+++ b/lib/noun.ex
@@ -89,8 +89,8 @@ defmodule Noun do
   @spec equal(t(), t()) :: boolean()
   def equal(noun_1, noun_2)
       when is_noun_atom(noun_1) and is_noun_atom(noun_2) do
-    normalized_noun_1 = normalize_noun_atom(noun_1)
-    normalized_noun_2 = normalize_noun_atom(noun_2)
+    normalized_noun_1 = normalize_noun(noun_1)
+    normalized_noun_2 = normalize_noun(noun_2)
 
     normalized_noun_1 == normalized_noun_2
   end
@@ -108,13 +108,19 @@ defmodule Noun do
   end
 
   # leave binaries, which are most likely to be large, as binaries.
-  @spec normalize_noun_atom(noun_atom()) :: binary()
-  def normalize_noun_atom(atom) when is_noun_atom(atom) do
+  @spec normalize_noun(noun_atom()) :: binary()
+  def normalize_noun(atom) when is_noun_atom(atom) do
     cond do
       atom == [] -> <<>>
       is_integer(atom) -> atom_integer_to_binary(atom)
       is_binary(atom) -> atom
     end
+  end
+
+  @spec normalize_noun(noun_cell()) :: Noun.t()
+  def normalize_noun(noun) when is_noun_cell(noun) do
+    [h | t] = noun
+    [normalize_noun(h) | normalize_noun(t)]
   end
 
   @spec index_to_offset(non_neg_integer()) :: non_neg_integer()

--- a/test/nock_test.exs
+++ b/test/nock_test.exs
@@ -277,6 +277,7 @@ defmodule AnomaTest.Nock do
     jam_and_cue([0 | 19], 39689)
     jam_and_cue([1 | 1], 817)
     jam_and_cue([10_000 | 10_000], 4_952_983_169)
+    jam_and_cue([65536 | <<0, 0, 1>>], 158_376_919_809)
     jam_and_cue([999_999_999 | 999_999_999], 1_301_217_674_263_809)
     jam_and_cue([222, 444 | 888], 250_038_217_192_960_129)
     jam_and_cue([[107 | 110] | [107 | 110]], 635_080_761_093)
@@ -338,7 +339,8 @@ defmodule AnomaTest.Nock do
   end
 
   def jam_and_cue(jam_value, cue_value) do
-    assert jam_value == Nock.Cue.cue!(cue_value)
+    assert Noun.equal(jam_value, Nock.Cue.cue!(cue_value))
     assert cue_value == Nock.Jam.jam(jam_value)
+    assert cue_value == Nock.Jam.jam(Noun.normalize_noun(jam_value))
   end
 end


### PR DESCRIPTION
A potential fix for:
* https://github.com/anoma/anoma/issues/550

I'm not sure that normalising atoms for the cache is correct. Should normalisation happen elsewhere or perhaps we should use binary atoms everywhere?

The jam implmentation uses a cache to record positions of jammed nouns. This is used to identify and write backrefs.

A normalized representation of a noun must be used as the cached key so that the same result is obtained when jamming equal nouns that use different integer/binary representations of atoms.

This existing Noun.normalize_noun_atom function (used in the Noun.equal implementation) is extended to cover cells and renamed to Noun.normalize_noun. This function is used to normalize nouns when updating or performing a lookup on the Jam cache.