### PR TITLE
Fix the block storage name for the transport engine

### DIFF
--- a/test/node/transport_test.exs
+++ b/test/node/transport_test.exs
@@ -22,7 +22,7 @@ defmodule AnomaTest.Node.Transport do
           [
             snapshot_path: snapshot_path,
             storage_data: storage,
-            block_storage: :mempool_blocks,
+            block_storage: :transport_blocks,
             ping_time: :no_timer
           ]
           |> Anoma.Node.start_min()


### PR DESCRIPTION
This may cause some tests to fail, not sure... so we fix the name. Artem had a better idea on how to fix this all.