### PR TITLE
Logging Using Elixir Logger On Dead Engine

### DIFF
--- a/lib/anoma/node/logger.ex
+++ b/lib/anoma/node/logger.ex
@@ -81,8 +81,10 @@ defmodule Anoma.Node.Logger do
 
   @spec add(Router.addr() | nil, atom(), String.t()) :: :ok | nil
   def add(logger, atom, msg) do
-    unless logger == nil do
+    if logger do
       Router.cast(logger, {:add, logger, atom, msg})
+    else
+      log_fun({atom, msg})
     end
   end
 


### PR DESCRIPTION
If the Logging Engine is dead, log info using the usual Elixir logger.