### PR TITLE
Use base32 encoding for socket filename generation

### DIFF
--- a/test/node/transport_test.exs
+++ b/test/node/transport_test.exs
@@ -42,6 +42,10 @@ defmodule AnomaTest.Node.Transport do
       {:unix, socket_path}
     )
 
+    # Ensure the Transport has started the server
+    # Please replace this with a topic listen
+    Router.call(node.transport, :ping)
+
     on_exit(fn ->
       File.rm(socket_path)
     end)


### PR DESCRIPTION
Base32 encoding does not contain any special symbols forbidden for use in file names.

Closes #471 