### PR TITLE
Update the manager type to have proper typing

### DIFF
--- a/lib/anoma/identity/manager.ex
+++ b/lib/anoma/identity/manager.ex
@@ -25,7 +25,10 @@ defmodule Anoma.Identity.Manager do
 
   @type resp(t) :: {:ok, t} | {:error, String.t()}
 
-  @type instance() :: %{commitment: pid(), decryption: pid()}
+  @type instance() :: %{
+          optional(:commitment) => pid(),
+          optional(:decryption) => pid()
+        }
 
   @spec generate(Backend.t(), Parameters.t(), Capabilities.t()) ::
           resp({instance(), Id.Extern.t()})
@@ -40,7 +43,7 @@ defmodule Anoma.Identity.Manager do
     )
 
     with {:ok, links} <- start_links(pair, cap) do
-      {links, pair.external}
+      {:ok, {links, pair.external}}
     end
   end
 

--- a/test/identity/manager_test.exs
+++ b/test/identity/manager_test.exs
@@ -37,14 +37,14 @@ defmodule AnomaTest.Identity.Manager do
   end
 
   test "Generating works", %{mem: mem} do
-    assert {%{commitment: com, decryption: _}, _} =
+    assert {:ok, {%{commitment: com, decryption: _}, _}} =
              Manager.generate(mem, :ed25519, :commit_and_decrypt)
 
     assert {:ok, _} = Commitment.commit(com, 555)
   end
 
   test "Can connect to generated id", %{mem: mem} do
-    {_, pub} = Manager.generate(mem, :ed25519, :commit_and_decrypt)
+    {:ok, {_, pub}} = Manager.generate(mem, :ed25519, :commit_and_decrypt)
 
     assert {:ok, %{commitment: com, decryption: _}} =
              Manager.connect(pub, mem, :commit_and_decrypt)
@@ -55,18 +55,18 @@ defmodule AnomaTest.Identity.Manager do
   test "Proper permissions", %{mem: mem} do
     generate = fn perms -> Manager.generate(mem, :ed25519, perms) end
 
-    assert {%{commitment: _, decryption: _}, _} =
+    assert {:ok, {%{commitment: _, decryption: _}, _}} =
              generate.(:commit_and_decrypt)
 
-    {com, _} = generate.(:commit)
-    {dec, _} = generate.(:decrypt)
+    {:ok, {com, _}} = generate.(:commit)
+    {:ok, {dec, _}} = generate.(:decrypt)
 
     refute Map.has_key?(com, :decryption) || Map.has_key?(dec, :commitment)
     assert Map.has_key?(com, :commitment) && Map.has_key?(dec, :decryption)
   end
 
   test "Deleting works", %{mem: mem} do
-    {_, pub} = Manager.generate(mem, :ed25519, :commit_and_decrypt)
+    {:ok, {_, pub}} = Manager.generate(mem, :ed25519, :commit_and_decrypt)
     Manager.delete(pub, mem)
     assert {:error, _} = Manager.connect(pub, mem, :commit_and_decrypt)
   end

--- a/test/identity/name_test.exs
+++ b/test/identity/name_test.exs
@@ -36,7 +36,10 @@ defmodule AnomaTest.Identity.Name do
 
   test "Properly reserve the ns", %{ns: namespace, mem: mem, st: storage} do
     Storage.ensure_new(storage)
-    {%{commitment: com}, pub} = Manager.generate(mem, :ed25519, :commit)
+
+    {:ok, {%{commitment: com}, pub}} =
+      Manager.generate(mem, :ed25519, :commit)
+
     {:ok, commited} = Commitment.commit(com, "Alice")
     name = [Name.name_space(), "Alice"]
     assert Name.reserve_namespace(namespace, "Alice", pub, commited) == :ok
@@ -46,7 +49,9 @@ defmodule AnomaTest.Identity.Name do
   test "Improper placement", %{ns: namespace, mem: mem, st: storage} do
     Storage.ensure_new(storage)
     # First pass all good
-    {%{commitment: com}, pub} = Manager.generate(mem, :ed25519, :commit)
+    {:ok, {%{commitment: com}, pub}} =
+      Manager.generate(mem, :ed25519, :commit)
+
     {:ok, commited} = Commitment.commit(com, "Alice")
     assert Name.reserve_namespace(namespace, "Alice", pub, commited) == :ok
     # no longer good
@@ -59,7 +64,10 @@ defmodule AnomaTest.Identity.Name do
 
   test "Adding to a namespace", %{ns: namespace, mem: mem, st: storage} do
     Storage.ensure_new(storage)
-    {%{commitment: com}, pub} = Manager.generate(mem, :ed25519, :commit)
+
+    {:ok, {%{commitment: com}, pub}} =
+      Manager.generate(mem, :ed25519, :commit)
+
     {:ok, commited} = Commitment.commit(com, "Alice")
 
     assert Name.reserve_namespace(namespace, "Alice", pub, commited) == :ok


### PR DESCRIPTION
We fix two things:

1. the instance types, the keys are optional.
2. The typing on `generate/3`, as it did not return an {:ok, res} when all is good