### PR TITLE
Add did not cover the full range of types it could return.

### DIFF
--- a/lib/anoma/identity/name.ex
+++ b/lib/anoma/identity/name.ex
@@ -30,7 +30,11 @@ defmodule Anoma.Identity.Name do
   namespace must have signed.
   """
   @spec add(t(), binary(), {list(binary()), binary()}) ::
-          :ok | :no_namespace | :failed_placement | :improper_data
+          :ok
+          | :no_namespace
+          | :failed_placement
+          | :improper_data
+          | :already_there
   def add(namespace = %__MODULE__{}, sig, d = {name, new_key})
       when is_list(name) do
     store = namespace.storage


### PR DESCRIPTION
We add the variant `:already_there`, as this shows up and we match it in a test. Examples have made this clear. And it shows up in a reserved namespace test, where we double add a name to make sure it doesn't get double added