### PR TITLE
Properly update the counter on the dumper

### DIFF
--- a/lib/anoma/node/dumper.ex
+++ b/lib/anoma/node/dumper.ex
@@ -137,7 +137,7 @@ defmodule Anoma.Node.Dumper do
             end)
 
           log_info({:new_task, task, logger})
-          {:ok, %Dumper{state | task: task}}
+          {:ok, %Dumper{state | count: count, task: task}}
         else
           {"Bad input", state}
         end


### PR DESCRIPTION
The dumper has logic to set the counter, however upon completeion it is never really set!

We have a test that checks for the value, but it just so happens to agree with the starting value, so this failure mode was never detected. When making exmaples I did catch this, and the test will show up in a future topic, but the change here should be obvious given the context.