### PR TITLE
Make workers temporary rather than transient

### DIFF
--- a/lib/anoma/node/executor/worker.ex
+++ b/lib/anoma/node/executor/worker.ex
@@ -22,7 +22,7 @@ defmodule Anoma.Node.Executor.Worker do
   alias Anoma.Node.{Storage, Ordering, Logger, Router}
   alias __MODULE__
 
-  use Router.Engine, restart: :transient
+  use Router.Engine, restart: :temporary
   use TypedStruct
 
   import Nock


### PR DESCRIPTION
If the workers are transient, then upon getting a kill message causes them to resapwn. This made some tests unreliable as the workers never truly died.

However, if we tried using `Router.stop_engine/3`, then it will take 5 seconds for each worker kill, as it's in the middle of waiting and it doesn't want to termiante while on the blocking read.

We can see this change below:

```diff
modified   lib/anoma/node/executor/executor.ex
@@ -143,7 +143,7 @@ defmodule Anoma.Node.Executor do
   end

   def handle_cast({:kill, _transactions}, _from, state) do
-    kill(state.workers)
+    kill(state.router, state.workers)
     {:noreply, %__MODULE__{state | workers: []}}
   end

@@ -166,14 +166,12 @@ defmodule Anoma.Node.Executor do
     addr
   end

-  @spec kill([Router.Addr.t()]) :: :ok
-  defp kill(workers) do
+  @spec kill(Router.Addr.t(), [Router.Addr.t()]) :: :ok
+  defp kill(router, workers) do # some tasks will have no pids because they have already terminated; cope

     workers
-    |> Enum.map(&Router.Addr.pid/1)
-    |> Enum.reject(&is_nil/1)
-    |> Enum.each(&Process.exit(&1, :kill))
+    |> Enum.each(&Router.stop_engine(router, &1))

     :ok
   end
```

We could keep them transient, but I'll have to edit some code and I'm unsure what we gain