### PR TITLE
Add the ability to reuse storage from another node.

### DIFF
--- a/lib/anoma/node.ex
+++ b/lib/anoma/node.ex
@@ -104,9 +104,14 @@ defmodule Anoma.Node do
   specific configuration settings. However if I'm a `:from_dump` then
   Ι have a superset of that information containing `mnesia` table
   configuration information as well.
+
+  If the mode is in `:existing_storage`, then Ι do nothing with the
+  given storage. I assume that the snapshot path is consistent between
+  this version of storage and what is configured in the node.
   """
   @type node_settings() ::
           {:new_storage, engine_configuration()}
+          | {:existing_storage, engine_configuration()}
           | {:from_dump, Anoma.Dump.dump()}
 
   @type min_engine_configuration() :: [
@@ -170,7 +175,18 @@ defmodule Anoma.Node do
     node_settings = {kind, settings} = args[:settings]
 
     {storage, block_storage} = storage_data(node_settings)
-    storage_setup(storage, block_storage, rocks)
+
+    # Clear out storage if the settings allow it
+    case kind do
+      :from_dump ->
+        storage_setup(storage, block_storage, rocks)
+
+      :new_storage ->
+        storage_setup(storage, block_storage, rocks)
+
+      :existing_storage ->
+        nil
+    end
 
     case kind do
       :from_dump ->

--- a/lib/examples/enode.ex
+++ b/lib/examples/enode.ex
@@ -26,6 +26,9 @@ defmodule Examples.ENode do
 
   @doc """
   We give an example of the full node!
+
+  We reuse the storage given in, so please keep the snapshot names
+  properly.
   """
   @spec fresh_full_node(Storage.t(), atom()) :: Node.t()
   @spec fresh_full_node(
@@ -52,7 +55,7 @@ defmodule Examples.ENode do
       Anoma.Node.start_link_or_find_instance(
         testing: true,
         use_rocks: false,
-        settings: {:new_storage, (options ++ config) |> Node.start_min()}
+        settings: {:existing_storage, (options ++ config) |> Node.start_min()}
       )
 
     Node.state(nodes)


### PR DESCRIPTION
Before when we passed storage to a node it would empty it out. This is unfortunate when it comes to examples as it would undo the hard work to setup the storage in a certain configuration. This patch fixes it as now we have storage persisting.

We may want to consider changing some of the engineering around this as we assume the snapshots share the same name which may cause issues when they are not the same between the two node setups.