### PR TITLE
Fix the encoding of `[]` to be that of 0.

### DIFF
--- a/lib/noun.ex
+++ b/lib/noun.ex
@@ -148,6 +148,10 @@ defmodule Noun do
 
   @spec atom_integer_to_binary(0) :: <<>>
   # special case: zero is the empty binary
+  def atom_integer_to_binary([]) do
+    atom_integer_to_binary(0)
+  end
+
   def atom_integer_to_binary(0) do
     <<>>
   end
@@ -173,5 +177,9 @@ defmodule Noun do
   def atom_binary_to_integer(integer)
       when is_integer(integer) and integer >= 0 do
     integer
+  end
+
+  def atom_binary_to_integer([]) do
+    atom_binary_to_integer(0)
   end
 end


### PR DESCRIPTION
THIS NEEDS TO BE REROLLED ONTO THE SPOT WHERE THE BUG IS MADE

Before the `Noun.atom_binary_to_integer/1`, and the `Noun.atom_integer_to_binary/*` would fail on []

Nock.Jam.jam([])
** (FunctionClauseError) no function clause matching in Noun.atom_binary_to_integer/1

However we maket he appropriate changes such that it would work no matter the circumstance.