### PR TITLE
Create a Glossery Module

### DIFF
--- a/lib/glossary.ex
+++ b/lib/glossary.ex
@@ -1,0 +1,10 @@
+defmodule Glossary do
+  @transaction_candidate """
+  A transaction candidate is `t:Noun.t/0` that evaluates to a valid or
+  invalid `transaction` for a specified
+  `t:Anoma.Node.Executor.Worker.backend/0`
+  """
+  @doc @transaction_candidate
+  @spec transaction_candidate() :: String.t()
+  def transaction_candidate(), do: @transaction_candidate
+end


### PR DESCRIPTION
At first we will fill in the glossary values by hand, like what we can see in this commit.

However, in the future we should fill it in with `defterm` or some similar macro that automates this process.

The general idea is that when we have common definitions, we can just link to the terms here for details. These can be moused over in the web extraction.