### PR TITLE
Add a custom transaction data type

### DIFF
--- a/lib/anoma/node/executor/worker.ex
+++ b/lib/anoma/node/executor/worker.ex
@@ -29,6 +29,8 @@ defmodule Anoma.Node.Executor.Worker do
 
   @type backend() :: :kv | :rm | :cairo | :ro
 
+  @type transaction() :: {backend(), Noun.t()}
+
   # TODO :: Please replace with a verify protocol
   @type verify_fun(trans) :: (trans -> boolean())
   @type from_noun(trans) :: (Noun.t() -> trans)
@@ -50,7 +52,7 @@ defmodule Anoma.Node.Executor.Worker do
     """
 
     field(:id, non_neg_integer())
-    field(:tx, {backend(), Noun.t()})
+    field(:tx, transaction())
     field(:env, Nock.t())
     field(:completion_topic, Router.Addr.t())
   end
@@ -68,10 +70,8 @@ defmodule Anoma.Node.Executor.Worker do
                                               a Worker instance.
   """
 
-  @spec init(
-          {non_neg_integer(), {backend(), Noun.t()}, Nock.t(),
-           Router.Addr.t()}
-        ) :: {:ok, Worker.t()}
+  @spec init({non_neg_integer(), transaction(), Nock.t(), Router.Addr.t()}) ::
+          {:ok, Worker.t()}
   def init({id, tx, env, completion_topic}) do
     send(self(), :run)
 


### PR DESCRIPTION
This is just a type alias. This allows us to do two things:

1. Have 1 spot that we update when we wish to change the type
2. Add documentation about the type of transactions