### PR TITLE
Abstract out the cli run command dispatch logic

### DIFF
--- a/lib/anoma/cli.ex
+++ b/lib/anoma/cli.ex
@@ -127,20 +127,8 @@ defmodule Anoma.Cli do
           System.halt(1)
         end
 
-      {:ok, [:submit], %{args: %{file: file}}} ->
-        run_client_command({:submit_tx, file})
-
-      {:ok, [:rm_submit], %{args: %{file: file}}} ->
-        run_client_command({:rm_submit_tx, file})
-
-      {:ok, [:get], %{args: %{key: key}}} ->
-        run_client_command({:get_key, key})
-
-      {:ok, [:shutdown], %{}} ->
-        run_client_command(:shutdown)
-
-      {:ok, [:nockma], parsed} ->
-        Nock.Cli.main(parsed)
+      {:ok, command, args} ->
+        run_commands({command, args})
         System.halt(0)
 
       :help ->
@@ -155,6 +143,38 @@ defmodule Anoma.Cli do
         top_level_help()
         System.halt(1)
     end
+  end
+
+  @spec run_commands({[client_commands(), ...], map()}) :: :ok | {:ok, any()}
+  @doc """
+  Runs the given client command
+  """
+  def run_commands({[:submit], %{args: %{file: file}}}) do
+    run_client_command({:submit_tx, file})
+  end
+
+  def run_commands({[:rm_submit], %{args: %{file: file}}}) do
+    run_client_command({:rm_submit_tx, file})
+  end
+
+  def run_commands({[:get], %{args: %{key: key}}}) do
+    run_client_command({:get_key, key})
+  end
+
+  def run_commands({[:shutdown], %{}}) do
+    run_client_command(:shutdown)
+  end
+
+  def run_commands({[:delete_dump], %{}}) do
+    run_client_command(:delete_dump)
+  end
+
+  def run_commands({[:snapshot], %{}}) do
+    run_client_command(:snapshot)
+  end
+
+  def run_commands({[:nockma], parsed}) do
+    Nock.Cli.main(parsed)
   end
 
   # Optimus.t() is opaque so the help fails to type check, but it's OK

--- a/lib/mix/tasks/client.ex
+++ b/lib/mix/tasks/client.ex
@@ -18,30 +18,11 @@ defmodule Mix.Tasks.Client do
   end
 
   def run(args) do
-    case Optimus.parse!(argument_parser(), args) do
-      {[:submit], %{args: %{file: file}}} ->
-        run_client_command({:submit_tx, file})
-
-      {[:rm_submit], %{args: %{file: file}}} ->
-        run_client_command({:rm_submit_tx, file})
-
-      {[:get], %{args: %{key: key}}} ->
-        run_client_command({:get_key, key})
-
-      {[:shutdown], %{}} ->
-        run_client_command(:shutdown)
-
-      {[:delete_dump], %{}} ->
-        run_client_command(:delete_dump)
-
-      {[:snapshot], %{}} ->
-        run_client_command(:snapshot)
-    end
-  end
-
-  defp run_client_command(operation) do
     Logger.configure(level: :error)
-    Anoma.Cli.run_client_command(operation)
+
+    Optimus.parse!(argument_parser(), args)
+    |> Anoma.Cli.run_commands()
+
     # We sleep as this does not wait for the client to finish, it'll
     # auto exit for us.
     Process.sleep(10_000_000)


### PR DESCRIPTION
We were copy and pasting the parse tree and dispatch tabled, this
unifies the design between the two different cli runners.