### PR TITLE
Change Logging Level Storage

### DIFF
--- a/lib/anoma/node/logger.ex
+++ b/lib/anoma/node/logger.ex
@@ -202,7 +202,7 @@ defmodule Anoma.Node.Logger do
 
     Storage.put(
       state.storage,
-      [logger.id, addr, Clock.get_time(state.clock), atom],
+      [logger.id, addr, Clock.get_time(state.clock), Atom.to_string(atom)],
       msg
     )
 

--- a/test/node/logger_test.exs
+++ b/test/node/logger_test.exs
@@ -64,6 +64,6 @@ defmodule AnomaTest.Node.Logger do
 
     assert log == logger.id
     assert ord == id
-    assert atom == :debug
+    assert atom == "debug"
   end
 end


### PR DESCRIPTION
Change logging level storage from using atoms to converting them to strings in order to respect the noun format.