### PR TITLE
Noun Zero Check

### DIFF
--- a/lib/noun.ex
+++ b/lib/noun.ex
@@ -107,6 +107,11 @@ defmodule Noun do
     false
   end
 
+  @spec is_zero(t()) :: boolean()
+  def is_zero(0), do: true
+  def is_zero(<<>>), do: true
+  def is_zero(_), do: false
+
   # leave binaries, which are most likely to be large, as binaries.
   @spec normalize_noun(noun_atom()) :: binary()
   def normalize_noun(atom) when is_noun_atom(atom) do


### PR DESCRIPTION
A 0 atom can either be 0 or <<>>, there are some checks that we should really be generic on 0 or <<>> on the elixir side, this lets us do that easily.