### PR TITLE
Make proof records contain binary not list(bin)

### DIFF
--- a/lib/anoma/shielded_resource/partial_transaction.ex
+++ b/lib/anoma/shielded_resource/partial_transaction.ex
@@ -50,7 +50,12 @@ defmodule Anoma.ShieldedResource.PartialTransaction do
           reduce: true do
         acc ->
           result =
-            Cairo.verify(proof_record.proof, proof_record.public_inputs)
+            proof_record.proof
+            |> :binary.bin_to_list()
+            |> Cairo.verify(
+              proof_record.public_inputs
+              |> :binary.bin_to_list()
+            )
 
           acc && result
       end
@@ -60,7 +65,12 @@ defmodule Anoma.ShieldedResource.PartialTransaction do
           reduce: true do
         acc ->
           result =
-            Cairo.verify(proof_record.proof, proof_record.public_inputs)
+            proof_record.proof
+            |> :binary.bin_to_list()
+            |> Cairo.verify(
+              proof_record.public_inputs
+              |> :binary.bin_to_list()
+            )
 
           Logger.debug("compliance result: #{inspect(result)}")
           acc && result

--- a/lib/anoma/shielded_resource/shielded_transaction.ex
+++ b/lib/anoma/shielded_resource/shielded_transaction.ex
@@ -95,6 +95,7 @@ defmodule Anoma.ShieldedResource.ShieldedTransaction do
         |> Enum.map(fn proof_record ->
           Anoma.SheildedResource.ComplianceOutput.from_public_input(
             proof_record.public_inputs
+            |> :binary.bin_to_list()
           )
         end)
       end)
@@ -126,7 +127,10 @@ defmodule Anoma.ShieldedResource.ShieldedTransaction do
       |> Enum.flat_map(fn ptx ->
         ptx.logic_proofs
         |> Enum.map(fn proof_record ->
-          Cairo.get_program_hash(proof_record.public_inputs)
+          Cairo.get_program_hash(
+            proof_record.public_inputs
+            |> :binary.bin_to_list()
+          )
         end)
       end)
 

--- a/test/node/executor/worker_test.exs
+++ b/test/node/executor/worker_test.exs
@@ -328,8 +328,8 @@ defmodule AnomaTest.Node.Executor.Worker do
     {proof, public_inputs} = Cairo.prove(trace, memory, public_inputs)
 
     compliance_proof = %ProofRecord{
-      proof: proof,
-      public_inputs: public_inputs
+      proof: proof |> :binary.list_to_bin(),
+      public_inputs: public_inputs |> :binary.list_to_bin()
     }
 
     # TODO: make up real logic proofs when building a client


### PR DESCRIPTION
Before they were the imporper type, because we treated them as lists, there is a mistaken idea that they really are