### PR TITLE
Add diriving of Transaction Inspect: Ignore tx Code

### DIFF
--- a/lib/anoma/transaction.ex
+++ b/lib/anoma/transaction.ex
@@ -12,6 +12,7 @@ defmodule Anoma.Transaction do
 
   @type execution() :: Worker.transaction()
 
+  @derive {Inspect, only: [:index, :id, :addr]}
   typedstruct do
     @typedoc """
     I am the type of the Anoma Transaction at the Engine level.


### PR DESCRIPTION
Printing Transaction structures in the REPL now ignores transaction code, making the outputs readable.