### PR TITLE
Add support for binary 0 for list_nock_to_erlang

### DIFF
--- a/lib/noun.ex
+++ b/lib/noun.ex
@@ -159,6 +159,11 @@ defmodule Noun do
     []
   end
 
+  @spec list_nock_to_erlang(<<>>) :: []
+  def list_nock_to_erlang(<<>>) do
+    []
+  end
+
   @spec list_nock_to_erlang([]) :: []
   def list_nock_to_erlang([]) do
     []


### PR DESCRIPTION
This matters for normalized nouns, as we often have

iex(mariari@Gensokyo)47> Noun.normalize_noun([1])
[<<1>> | ""]

that we wish to turn into a normal erlang list