### PR TITLE
shielded resource existence check

### DIFF
--- a/lib/anoma/node/executor/worker.ex
+++ b/lib/anoma/node/executor/worker.ex
@@ -232,8 +232,8 @@ defmodule Anoma.Node.Executor.Worker do
          {:ok, vm_resource_tx} <- mod.from_noun(resource_tx),
          true_order = wait_for_ready(s),
          true <- Transaction.verify(vm_resource_tx),
-         # TODO: add root existence check. The roots must be traceable
-         # in historical records.
+         true <-
+           Transaction.resource_existence_check(vm_resource_tx, storage),
          true <-
            rm_nullifier_check(
              storage,
@@ -279,9 +279,9 @@ defmodule Anoma.Node.Executor.Worker do
       log_info({:put, cm_key, logger})
     end
 
-    CommitmentTree.add(cm_tree, commitments)
+    {_ct, anchor} = CommitmentTree.add(cm_tree, commitments)
 
-    Storage.put(storage, ["rm", "commitment_root"], cm_tree.root)
+    Storage.put(storage, ["rm", "commitment_root", anchor], true)
 
     for nullifier <- Transaction.storage_nullifiers(vm_resource_tx) do
       nf_key = ["rm", "nullifiers", nullifier]

--- a/lib/anoma/resource/transaction.ex
+++ b/lib/anoma/resource/transaction.ex
@@ -205,5 +205,10 @@ defmodule Anoma.Resource.Transaction do
         Anoma.Node.Router.Engine.get_state(storage).rm_commitments
       )
     end
+
+    # TODO: add the check for transparent resources
+    def resource_existence_check(_transaction, _storage) do
+      true
+    end
   end
 end

--- a/lib/anoma/rm/transaction.ex
+++ b/lib/anoma/rm/transaction.ex
@@ -10,6 +10,9 @@ defprotocol Anoma.RM.Transaction do
   @doc """
   I compose two transactions into a new transaction
   """
+
+  alias Anoma.Node.Router
+
   @spec compose(t(), t()) :: t()
   def compose(tx1, tx2)
 
@@ -30,6 +33,9 @@ defprotocol Anoma.RM.Transaction do
 
   @spec cm_tree(t(), term()) :: CommitmentTree.t()
   def cm_tree(transaction, storage)
+
+  @spec resource_existence_check(t(), Router.addr()) :: boolean()
+  def resource_existence_check(transaction, storage)
 end
 
 defmodule Anoma.RM.Trans do

--- a/test/node/executor/worker_test.exs
+++ b/test/node/executor/worker_test.exs
@@ -341,6 +341,12 @@ defmodule AnomaTest.Node.Executor.Worker do
       }
       |> ShieldedTransaction.finalize()
 
+    # Mock root history: insert the cuurent roots to the storage
+    rm_tx.roots
+    |> Enum.each(fn root ->
+      Storage.put(storage, ["rm", "commitment_root", root], true)
+    end)
+
     rm_tx_noun = Noun.Nounable.to_noun(rm_tx)
     rm_executor_tx = [[1 | rm_tx_noun], 0 | 0]
 


### PR DESCRIPTION
The name "resource existence check" sounds better to me than "root check". 
I added the interface `resource_existence_check` in `Anoma.RM.Transaction`, but I left the impl of check in transparent cases a TODO. You probably need some other checks on that. Let me know if you think it makes sense. @juped 

The bug in ShieldedTransaction `from_noun` should be fixed in #742
The PR needs to be rebased and use the updated storage APIs once the storage PRs are finalized and merged.