### PR TITLE
Fix Connection Death Spam upon a socket closing

### DIFF
--- a/lib/anoma/node/transport/tcp_connection.ex
+++ b/lib/anoma/node/transport/tcp_connection.ex
@@ -119,10 +119,10 @@ defmodule Anoma.Node.Transport.TCPConnection do
 
   def handle_continue(:accept_connection, s) do
     res = :gen_tcp.accept(s.listener)
-    start_listener(s)
 
     case res do
       {:ok, conn} ->
+        start_listener(s)
         # need to figure out if unix or tcp
         Transport.new_connection(s.transport, :unix)
         {:noreply, %{s | conn: conn}}


### PR DESCRIPTION
Closes #808

As seen in:

https://github.com/anoma/anoma/issues/808

running

```elixir
anode = ENode.simple_router()
{anode, socks} = ENode.attach_socks(anode, cleanup: false)

process_identity = Engine.get_state(anode.transport).servers[socks]
listener = Engine.get_state(process_identity).listener
:gen_tcp.close(listener)
```

will kill one's Elixir node, as process will restart over and over

This fixes that issue by simplying moving where the start Listener is.

This further fixes tests being spammed with failures as you can read below

```
13:00:57.369 [error] GenServer :"Anoma.Node.Transport.TCPConnection gmGhonPVIvVxyWGsqHJg+TqF1ZpScPUIohCPQKYul3Q=" terminating
** (stop) exited in: GenServer.call(:"Anoma.Node.Router ymQNFBLRp8v/66Y3n1kl+p9zzXgA560kAc8Rng8aDDk=", {:router_call, %RID{id: %Pub{encrypt: 0x839aac..., sign: 0x8261a1...} MOD: Anoma.Node.Transport.TCPConnection}, :supervisor}, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
    (elixir 1.15.5) lib/gen_server.ex:1063: GenServer.call/3
    (anoma 0.19.1) lib/anoma/node/router.ex:511: Anoma.Node.Router.start_engine/4
    (anoma 0.19.1) lib/anoma/node/transport/tcp_connection.ex:122: Anoma.Node.Transport.TCPConnection.handle_continue/2
    (anoma 0.19.1) lib/anoma/node/router/engine.ex:264: Anoma.Node.Router.Engine.handle_continue/2
    (stdlib 5.2) gen_server.erl:1085: :gen_server.try_handle_continue/3
    (stdlib 5.2) gen_server.erl:995: :gen_server.loop/7
    (stdlib 5.2) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
Last message: {:continue, :accept_connection}

13:00:57.369 [error] GenServer :"Anoma.Node.Transport.TCPConnection /cIjAh09ilZKRdHqOn8v4WHfkAKRt55TH0opvqiICZ4=" terminating
** (stop) exited in: GenServer.call(:"Anoma.Node.Router orLMr5zNEDXX6glEDM9nUf7oegNAwroSe7u0VOeltzU=", {:router_call, %RID{id: %Pub{encrypt: 0x9f9d57..., sign: 0xfdc223...} MOD: Anoma.Node.Transport.TCPConnection}, :supervisor}, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
    (elixir 1.15.5) lib/gen_server.ex:1063: GenServer.call/3
    (anoma 0.19.1) lib/anoma/node/router.ex:511: Anoma.Node.Router.start_engine/4
    (anoma 0.19.1) lib/anoma/node/transport/tcp_connection.ex:122: Anoma.Node.Transport.TCPConnection.handle_continue/2
    (anoma 0.19.1) lib/anoma/node/router/engine.ex:264: Anoma.Node.Router.Engine.handle_continue/2
    (stdlib 5.2) gen_server.erl:1085: :gen_server.try_handle_continue/3
    (stdlib 5.2) gen_server.erl:995: :gen_server.loop/7
    (stdlib 5.2) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
Last message: {:continue, :accept_connection}

13:00:57.372 [error] Process :"Anoma.Node.Transport.TCPConnection gmGhonPVIvVxyWGsqHJg+TqF1ZpScPUIohCPQKYul3Q=" (#PID<0.6263.0>) terminating
** (exit) exited in: GenServer.call(:"Anoma.Node.Router ymQNFBLRp8v/66Y3n1kl+p9zzXgA560kAc8Rng8aDDk=", {:router_call, %RID{id: %Pub{encrypt: 0x839aac..., sign: 0x8261a1...} MOD: Anoma.Node.Transport.TCPConnection}, :supervisor}, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
    (elixir 1.15.5) lib/gen_server.ex:1063: GenServer.call/3
    (anoma 0.19.1) lib/anoma/node/router.ex:511: Anoma.Node.Router.start_engine/4
    (anoma 0.19.1) lib/anoma/node/transport/tcp_connection.ex:122: Anoma.Node.Transport.TCPConnection.handle_continue/2
    (anoma 0.19.1) lib/anoma/node/router/engine.ex:264: Anoma.Node.Router.Engine.handle_continue/2
    (stdlib 5.2) gen_server.erl:1085: :gen_server.try_handle_continue/3
    (stdlib 5.2) gen_server.erl:995: :gen_server.loop/7
    (stdlib 5.2) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
Initial Call: Anoma.Node.Router.Engine.init/1
Ancestors: [#PID<0.6188.0>, :"supervisor ymQNFBLRp8v/66Y3n1kl+p9zzXgA560kAc8Rng8aDDk=", :"Elixir.Examples.ENode.EStorage.storage_423_from_c", #PID<0.5945.0>]

13:00:57.372 [error] Process :"Anoma.Node.Transport.TCPConnection /cIjAh09ilZKRdHqOn8v4WHfkAKRt55TH0opvqiICZ4=" (#PID<0.6105.0>) terminating
** (exit) exited in: GenServer.call(:"Anoma.Node.Router orLMr5zNEDXX6glEDM9nUf7oegNAwroSe7u0VOeltzU=", {:router_call, %RID{id: %Pub{encrypt: 0x9f9d57..., sign: 0xfdc223...} MOD: Anoma.Node.Transport.TCPConnection}, :supervisor}, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
    (elixir 1.15.5) lib/gen_server.ex:1063: GenServer.call/3
    (anoma 0.19.1) lib/anoma/node/router.ex:511: Anoma.Node.Router.start_engine/4
    (anoma 0.19.1) lib/anoma/node/transport/tcp_connection.ex:122: Anoma.Node.Transport.TCPConnection.handle_continue/2
    (anoma 0.19.1) lib/anoma/node/router/engine.ex:264: Anoma.Node.Router.Engine.handle_continue/2
    (stdlib 5.2) gen_server.erl:1085: :gen_server.try_handle_continue/3
    (stdlib 5.2) gen_server.erl:995: :gen_server.loop/7
    (stdlib 5.2) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
Initial Call: Anoma.Node.Router.Engine.init/1
Ancestors: [#PID<0.6030.0>, :"supervisor orLMr5zNEDXX6glEDM9nUf7oegNAwroSe7u0VOeltzU=", :"Elixir.Examples.ENode.EStorage.get_from_other", #PID<0.5945.0>]

13:00:57.372 [error] Child :undefined of Supervisor #PID<0.6188.0> (Anoma.Node.Transport.Supervisor) shut down abnormally
** (exit) exited in: GenServer.call(:"Anoma.Node.Router ymQNFBLRp8v/66Y3n1kl+p9zzXgA560kAc8Rng8aDDk=", {:router_call, %RID{id: %Pub{encrypt: 0x839aac..., sign: 0x8261a1...} MOD: Anoma.Node.Transport.TCPConnection}, :supervisor}, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
Pid: #PID<0.6263.0>
Start Call: Anoma.Node.Router.Engine.start_link({%RID{id: %Pub{encrypt: 0xd7a305..., sign: 0xca640d...} MOD: Anoma.Node.Router}, Anoma.Node.Transport.TCPConnection, %Anoma.Crypto.Id{kind_encrypt: :box, kind_sign: :ed25519, external: %Pub{encrypt: 0x839aac..., sign: 0x8261a1...}, internal: %Sec{encrypt: 0x20bc34..., sign: 0x2e8c41...}}, {:listener, %RID{id: %Pub{encrypt: 0xd7a305..., sign: 0xca640d...} MOD: Anoma.Node.Router}, %RID{id: %Pub{encrypt: 0x1cadee..., sign: 0x155afd...} MOD: Anoma.Node.Transport}, #Port<0.27>, #PID<0.6188.0>}})

13:00:57.372 [error] Child :undefined of Supervisor #PID<0.6030.0> (Anoma.Node.Transport.Supervisor) shut down abnormally
** (exit) exited in: GenServer.call(:"Anoma.Node.Router orLMr5zNEDXX6glEDM9nUf7oegNAwroSe7u0VOeltzU=", {:router_call, %RID{id: %Pub{encrypt: 0x9f9d57..., sign: 0xfdc223...} MOD: Anoma.Node.Transport.TCPConnection}, :supervisor}, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
Pid: #PID<0.6105.0>
Start Call: Anoma.Node.Router.Engine.start_link({%RID{id: %Pub{encrypt: 0x6fa22f..., sign: 0xa2b2cc...} MOD: Anoma.Node.Router}, Anoma.Node.Transport.TCPConnection, %Anoma.Crypto.Id{kind_encrypt: :box, kind_sign: :ed25519, external: %Pub{encrypt: 0x9f9d57..., sign: 0xfdc223...}, internal: %Sec{encrypt: 0x15e0ab..., sign: 0x823ea3...}}, {:listener, %RID{id: %Pub{encrypt: 0x6fa22f..., sign: 0xa2b2cc...} MOD: Anoma.Node.Router}, %RID{id: %Pub{encrypt: 0xc3192e..., sign: 0xfac83a...} MOD: Anoma.Node.Transport}, #Port<0.22>, #PID<0.6030.0>}})
...

```