### PR TITLE
Validate Anoma.Node startup

### DIFF
--- a/lib/anoma/node.ex
+++ b/lib/anoma/node.ex
@@ -149,6 +149,14 @@ defmodule Anoma.Node do
 
   @spec start_link(configuration()) :: GenServer.on_start()
   def start_link(args) do
+    args =
+      Keyword.validate!(args, [
+        :name,
+        :settings,
+        use_rocks: true,
+        testing: false
+      ])
+
     # strawman pending proper lockfiles
     # also need to clean this up once we're done
     unix_path = Anoma.System.Directories.data("local.sock")


### PR DESCRIPTION
Before we could pass in incorrect arguments, meaning that upon refactoring we could miss passing stale arguments.

To better handle this we have changed the code to use Keyword.validate!/2

See

https://github.com/anoma/anoma/issues/537

for more details

Closes #537 