### PR TITLE
Rename resource structure field

### DIFF
--- a/hoon/resource-machine.hoon
+++ b/hoon/resource-machine.hoon
@@ -9,7 +9,7 @@
     logic=resource-logic
     label=@t
     quantity=@
-    data=@
+    value=@
     eph=?
     nonce=@
     npk=@


### PR DESCRIPTION
Rename the resource structure field in accordance with the v2 Resource Machine specs.
The fix does not change the generated Nock code for the resource machine.

Fixes #506 