### PR TITLE
fix duplicate nfs in cairo RM

### DIFF
--- a/apps/anoma_lib/lib/anoma/shielded_resource/shielded_transaction.ex
+++ b/apps/anoma_lib/lib/anoma/shielded_resource/shielded_transaction.ex
@@ -150,7 +150,12 @@ defmodule Anoma.ShieldedResource.ShieldedTransaction do
       resource_logic_valid =
         resource_logics_from_compliance == resource_logic_from_program
 
-      all_proofs_valid && delta_valid && resource_logic_valid
+      # check duplicate nfs
+      has_duplicate_nfs =
+        Enum.uniq(transaction.nullifiers) == transaction.nullifiers
+
+      all_proofs_valid && delta_valid && resource_logic_valid &&
+        has_duplicate_nfs
     end
 
     def cm_tree(_tx, _storage) do


### PR DESCRIPTION
close anoma/anoma-archive#1291 

The issue can be resolved by checking duplicate nfs in one transaction.

The merge should not be done until the worker refactor is completed, and a test should be added for it afterwards.