### PR TITLE
Add a Ulitily Folder and Supervisor

### DIFF
--- a/apps/anoma_node/lib/node/supervisor.ex
+++ b/apps/anoma_node/lib/node/supervisor.ex
@@ -12,7 +12,8 @@ defmodule Anoma.Node.Supervisor do
   def init(_args) do
     children = [
       Anoma.Node.Transaction.Supervisor,
-      Anoma.Node.Transport.Supervisor
+      Anoma.Node.Transport.Supervisor,
+      Anoma.Node.Utility.Supervisor
     ]
 
     Supervisor.init(children, strategy: :one_for_all)

--- a/apps/anoma_node/lib/node/utility/supervisor.ex
+++ b/apps/anoma_node/lib/node/utility/supervisor.ex
@@ -1,0 +1,15 @@
+defmodule Anoma.Node.Utility.Supervisor do
+  @moduledoc """
+  I am the supervisor for the utility subsystem.
+  """
+
+  use Supervisor
+
+  def start_link(args) do
+    Supervisor.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  def init(_args) do
+    Supervisor.init([], strategy: :one_for_all)
+  end
+end


### PR DESCRIPTION
Add Utility folder with a Supervisor. The Utility subsystem is responsible for 1-engine processes used for the purposes of the testnet such as trivial consensus and indexer.